### PR TITLE
Remove direct reference to proto enums for protobuf < 3.8.0

### DIFF
--- a/src/cisco_gnmi/client.py
+++ b/src/cisco_gnmi/client.py
@@ -116,8 +116,8 @@ class Client(object):
         self,
         paths,
         prefix=None,
-        data_type=proto.gnmi_pb2.GetRequest.DataType.ALL,
-        encoding=proto.gnmi_pb2.Encoding.JSON_IETF,
+        data_type="ALL",
+        encoding="JSON_IETF",
         use_models=None,
         extension=None,
     ):


### PR DESCRIPTION
Proto enums are not directly accessible until 3.8.0, < 3.8.0 usage is key or value based.
Thanks @byzek 

Related to #28 