### PR TITLE
Replace proto append with extend for protobuf < 3.8.0

### DIFF
--- a/src/cisco_gnmi/nx.py
+++ b/src/cisco_gnmi/nx.py
@@ -123,6 +123,7 @@ class NXClient(Client):
         )
         if isinstance(xpath_subscriptions, string_types):
             xpath_subscriptions = [xpath_subscriptions]
+        subscriptions = []
         for xpath_subscription in xpath_subscriptions:
             subscription = None
             if isinstance(xpath_subscription, string_types):
@@ -159,7 +160,8 @@ class NXClient(Client):
                 subscription = xpath_subscription
             else:
                 raise Exception("xpath in list must be xpath or dict/Path!")
-            subscription_list.subscription.append(subscription)
+            subscriptions.append(subscription)
+        subscription_list.subscription.extend(subscriptions)
         return self.subscribe([subscription_list])
 
     def parse_xpath_to_gnmi_path(self, xpath, origin=None):

--- a/src/cisco_gnmi/xe.py
+++ b/src/cisco_gnmi/xe.py
@@ -270,6 +270,7 @@ class XEClient(Client):
         )
         if isinstance(xpath_subscriptions, string_types):
             xpath_subscriptions = [xpath_subscriptions]
+        subscriptions = []
         for xpath_subscription in xpath_subscriptions:
             subscription = None
             if isinstance(xpath_subscription, string_types):
@@ -306,7 +307,8 @@ class XEClient(Client):
                 subscription = xpath_subscription
             else:
                 raise Exception("xpath in list must be xpath or dict/Path!")
-            subscription_list.subscription.append(subscription)
+            subscriptions.append(subscription)
+        subscription_list.subscription.extend(subscriptions)
         return self.subscribe([subscription_list])
 
     def parse_xpath_to_gnmi_path(self, xpath, origin=None):

--- a/src/cisco_gnmi/xr.py
+++ b/src/cisco_gnmi/xr.py
@@ -284,6 +284,7 @@ class XRClient(Client):
         )
         if isinstance(xpath_subscriptions, string_types):
             xpath_subscriptions = [xpath_subscriptions]
+        subscriptions = []
         for xpath_subscription in xpath_subscriptions:
             subscription = None
             if isinstance(xpath_subscription, string_types):
@@ -324,7 +325,8 @@ class XRClient(Client):
                 subscription = xpath_subscription
             else:
                 raise Exception("xpath in list must be xpath or dict/Path!")
-            subscription_list.subscription.append(subscription)
+            subscriptions.append(subscription)
+        subscription_list.subscription.extend(subscriptions)
         return self.subscribe([subscription_list])
 
     def parse_xpath_to_gnmi_path(self, xpath, origin=None):


### PR DESCRIPTION
`append` is not a supported protobuf operation < 3.8.0, similar to the enum issues.
This just let's us have all the compatibility desired as a library.

Related to #28 