### PR TITLE
Convenient wrappers for system formatted ASCII text (CLI) - IOS-XR

### DIFF
--- a/src/cisco_gnmi/client.py
+++ b/src/cisco_gnmi/client.py
@@ -334,19 +334,3 @@ class Client(object):
             raise Exception("Unfinished elements in XPath parsing!")
         path.elem.extend(path_elems)
         return path
-
-    def parse_cli_command_to_gnmi_path(self, cli_command):
-        """Parses a CLI command to proto.gnmi_pb2.Path.
-        This function should be overridden by any child classes for origin logic.
-
-        The CLI command becomes a path element.
-        """
-        if not isinstance(cli_command, string_types):
-            raise Exception("cli_command must be a string!")
-
-        path = proto.gnmi_pb2.Path()
-        curr_elem = proto.gnmi_pb2.PathElem()
-        curr_elem.name = cli_command
-        path.elem.extend([curr_elem])
-
-        return path

--- a/src/cisco_gnmi/client.py
+++ b/src/cisco_gnmi/client.py
@@ -334,3 +334,19 @@ class Client(object):
             raise Exception("Unfinished elements in XPath parsing!")
         path.elem.extend(path_elems)
         return path
+
+    def parse_cli_command_to_gnmi_path(self, cli_command):
+        """Parses a CLI command to proto.gnmi_pb2.Path.
+        This function should be overridden by any child classes for origin logic.
+
+        The CLI command becomes a path element.
+        """
+        if not isinstance(cli_command, string_types):
+            raise Exception("cli_command must be a string!")
+
+        path = proto.gnmi_pb2.Path()
+        curr_elem = proto.gnmi_pb2.PathElem()
+        curr_elem.name = cli_command
+        path.elem.extend([curr_elem])
+
+        return path

--- a/src/cisco_gnmi/xr.py
+++ b/src/cisco_gnmi/xr.py
@@ -367,3 +367,19 @@ class XRClient(Client):
             )
         return self.get(gnmi_path, encoding='ASCII')
 
+    def parse_cli_command_to_gnmi_path(self, cli_command):
+        """Parses a CLI command to proto.gnmi_pb2.Path.
+        This function should be overridden by any child classes for origin logic.
+
+        The CLI command becomes a path element.
+        """
+        if not isinstance(cli_command, string_types):
+            raise Exception("cli_command must be a string!")
+
+        path = proto.gnmi_pb2.Path()
+        curr_elem = proto.gnmi_pb2.PathElem()
+        curr_elem.name = cli_command
+        path.elem.extend([curr_elem])
+
+        return path
+

--- a/src/cisco_gnmi/xr.py
+++ b/src/cisco_gnmi/xr.py
@@ -342,3 +342,42 @@ class XRClient(Client):
                 # module name
                 origin, xpath = xpath.split(":", 1)
         return super(XRClient, self).parse_xpath_to_gnmi_path(xpath, origin)
+
+    def get_cli_commands(self, cli_commands):
+        """A convenience wrapper for get() which forms proto.gnmi_pb2.Path from supplied CLI commands.
+
+        Parameters
+        ----------
+        cli_commands : iterable of str or str
+            An iterable of CLI commands as strings to request data of
+            If simply a str, wraps as a list for convenience
+
+        Returns
+        -------
+        get()
+        """
+        gnmi_path = None
+        if isinstance(cli_commands, (list, set)):
+            gnmi_path = map(self.parse_cli_command_to_gnmi_path, set(cli_commands))
+        elif isinstance(cli_commands, string_types):
+            gnmi_path = [self.parse_cli_command_to_gnmi_path(cli_commands)]
+        else:
+            raise Exception(
+                "cli_commands must be a single CLI command string or iterable of CLI commands as strings!"
+            )
+        return self.get(gnmi_path, encoding='ASCII')
+
+    def parse_cli_command_to_gnmi_path(self, cli_command):
+        """A convenience wrapper for parse_cli_command_to_gnmi_path() that creates the proto.gnmi_pb2.Path for the
+        supplied CLI command.
+
+        Parameters
+        ----------
+        cli_command : str
+            A CLI command as str
+
+        Returns
+        -------
+        parse_cli_command_to_gnmi_path()
+        """
+        return super(XRClient, self).parse_cli_command_to_gnmi_path(cli_command)

--- a/src/cisco_gnmi/xr.py
+++ b/src/cisco_gnmi/xr.py
@@ -367,17 +367,3 @@ class XRClient(Client):
             )
         return self.get(gnmi_path, encoding='ASCII')
 
-    def parse_cli_command_to_gnmi_path(self, cli_command):
-        """A convenience wrapper for parse_cli_command_to_gnmi_path() that creates the proto.gnmi_pb2.Path for the
-        supplied CLI command.
-
-        Parameters
-        ----------
-        cli_command : str
-            A CLI command as str
-
-        Returns
-        -------
-        parse_cli_command_to_gnmi_path()
-        """
-        return super(XRClient, self).parse_cli_command_to_gnmi_path(cli_command)


### PR DESCRIPTION
Simple wrapper for system formatted text. This applies specifically to input in ASCII format.

The following two methods were created:
- `get_cli_commands()`
- `parse_cli_command_to_gnmi_path()`

The development was focused on IOS-XR but could be refactored so as to cover other OS's.

For a robust parsing of CLI commands, one could consider using the **genieparser** (https://github.com/CiscoTestAutomation/genieparser) that has built-in parses for specific CLI commands.
