### PR TITLE
Add cli.py as cisco-gnmi to demonstrate cisco_gnmi usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,36 @@
 
 This library wraps gNMI functionality to ease usage with Cisco implementations in Python programs. Derived from [openconfig/gnmi](https://github.com/openconfig/gnmi/tree/master/proto).
 
+- [cisco-gnmi-python](#cisco-gnmi-python)
+  - [Usage](#usage)
+    - [cisco-gnmi CLI](#cisco-gnmi-cli)
+    - [ClientBuilder](#clientbuilder)
+      - [Initialization Examples](#initialization-examples)
+    - [Client](#client)
+    - [NXClient](#nxclient)
+    - [XEClient](#xeclient)
+    - [XRClient](#xrclient)
+  - [gNMI](#gnmi)
+  - [Development](#development)
+    - [Get Source](#get-source)
+    - [Code Hygiene](#code-hygiene)
+    - [Recompile Protobufs](#recompile-protobufs)
+  - [CLI Usage](#cli-usage)
+    - [Capabilities](#capabilities)
+      - [Usage](#usage-1)
+      - [Output](#output)
+    - [Get](#get)
+      - [Usage](#usage-2)
+      - [Output](#output-1)
+    - [Set](#set)
+      - [Usage](#usage-3)
+    - [Subscribe](#subscribe)
+      - [Usage](#usage-4)
+      - [Output](#output-2)
+  - [Licensing](#licensing)
+  - [Issues](#issues)
+  - [Related Projects](#related-projects)
+
 ## Usage
 ```bash
 pip install cisco-gnmi
@@ -185,7 +215,7 @@ If a new `gnmi.proto` definition is released, use `update_protos.sh` to recompil
 ./update_protos.sh
 ```
 
-### CLI Usage
+## CLI Usage
 The below details the current `cisco-gnmi` usage options. Please note that `Set` operations may be destructive to operations and should be tested in lab conditions.
 
 ```
@@ -216,12 +246,13 @@ optional arguments:
   -h, --help  show this help message and exit
 ```
 
-#### Capabilities
+### Capabilities
 This command will output the `CapabilitiesResponse` to `stdout`.
 ```
 cisco-gnmi capabilities 127.0.0.1:57500 -auto_ssl_target_override
 ```
 
+#### Usage
 ```
 cisco-gnmi capabilities --help
 usage: cisco-gnmi [-h] [-os {None,IOS XR,NX-OS,IOS XE}]
@@ -255,12 +286,27 @@ optional arguments:
   -debug                Print debug messages.
 ```
 
-#### Get
+#### Output
+```
+[cisco-gnmi-python] cisco-gnmi capabilities redacted:57500 -auto_ssl_target_override
+Username: admin
+Password:
+WARNING:root:Overriding SSL option from certificate could increase MITM susceptibility!
+INFO:root:supported_models {
+  name: "Cisco-IOS-XR-qos-ma-oper"
+  organization: "Cisco Systems, Inc."
+  version: "2019-04-05"
+}
+...
+```
+
+### Get
 This command will output the `GetResponse` to `stdout`. `-xpath` may be specified multiple times to specify multiple `Path`s for the `GetRequest`.
 ```
 cisco-gnmi get 127.0.0.1:57500 -os "IOS XR" -xpath /interfaces/interface/state/counters -auto_ssl_target_override
 ```
 
+#### Usage
 ```
 usage: cisco-gnmi [-h] [-xpath XPATH]
               [-encoding [{JSON,BYTES,PROTO,ASCII,JSON_IETF}]]
@@ -302,8 +348,37 @@ optional arguments:
   -debug                Print debug messages.
 ```
 
-#### Set
+#### Output
+```
+[cisco-gnmi-python] cisco-gnmi get redacted:57500 -os "IOS XR" -xpath /interfaces/interface/state/counters -auto_ssl_target_override
+Username: admin
+Password:
+WARNING:root:Overriding SSL option from certificate could increase MITM susceptibility!
+INFO:root:notification {
+  timestamp: 1585607100869287743
+  update {
+    path {
+      elem {
+        name: "interfaces"
+      }
+      elem {
+        name: "interface"
+      }
+      elem {
+        name: "state"
+      }
+      elem {
+        name: "counters"
+      }
+    }
+    val {
+      json_ietf_val: "{\"in-unicast-pkts\":\"0\",\"in-octets\":\"0\"...
+```
+
+### Set
 This command has not been validated. Please note that `Set` operations may be destructive to operations and should be tested in lab conditions.
+
+#### Usage
 ```
 usage: cisco-gnmi [-h] [-update_json_config UPDATE_JSON_CONFIG]
               [-replace_json_config REPLACE_JSON_CONFIG]
@@ -347,12 +422,13 @@ optional arguments:
   -debug                Print debug messages.
 ```
 
-#### Subscribe
+### Subscribe
 This command will output the `SubscribeResponse` to `stdout` or `-dump_file`. `-xpath` may be specified multiple times to specify multiple `Path`s for the `GetRequest`. Subscribe currently only supports a sampled stream. `ON_CHANGE` is possible but not implemented in the CLI, yet. :)
 ```
 cisco-gnmi subscribe 127.0.0.1:57500 -os "IOS XR" -xpath /interfaces/interface/state/counters -auto_ssl_target_override
 ```
 
+#### Usage
 ```
 cisco-gnmi subscribe --help
 usage: cisco-gnmi [-h] [-xpath XPATH] [-interval INTERVAL] [-dump_file DUMP_FILE]
@@ -395,6 +471,49 @@ optional arguments:
                         Use root_certificates first CN as
                         grpc.ssl_target_name_override.
   -debug                Print debug messages.
+```
+
+#### Output
+```
+[cisco-gnmi-python] cisco-gnmi subscribe redacted:57500 -os "IOS XR" -xpath /interfaces/interface/state/counters -auto_ssl_target_override
+Username: admin
+Password:
+WARNING:root:Overriding SSL option from certificate could increase MITM susceptibility!
+INFO:root:Dumping responses to stdout as textual proto ...
+INFO:root:Subscribing to:
+/interfaces/interface/state/counters
+INFO:root:update {
+  timestamp: 1585607768601000000
+  prefix {
+    origin: "openconfig"
+    elem {
+      name: "interfaces"
+    }
+    elem {
+      name: "interface"
+      key {
+        key: "name"
+        value: "Null0"
+      }
+    }
+    elem {
+      name: "state"
+    }
+    elem {
+      name: "counters"
+    }
+  }
+  update {
+    path {
+      elem {
+        name: "in-octets"
+      }
+    }
+    val {
+      uint_val: 0
+    }
+  }
+...
 ```
 
 ## Licensing

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ This library wraps gNMI functionality to ease usage with Cisco implementations i
 ```bash
 pip install cisco-gnmi
 python -c "import cisco_gnmi; print(cisco_gnmi)"
-gnmcli --help
+cisco-gnmi --help
 ```
 
-This library covers the gNMI defined `Capabilities`, `Get`, `Set`, and `Subscribe` RPCs, and helper clients provide OS-specific recommendations. A CLI is also available. As commonalities and differences are identified between OS functionality this library will be refactored as necessary.
+This library covers the gNMI defined `Capabilities`, `Get`, `Set`, and `Subscribe` RPCs, and helper clients provide OS-specific recommendations. A CLI (`cisco-gnmi`) is also available upon installation. As commonalities and differences are identified between OS functionality this library will be refactored as necessary.
 
 It is *highly* recommended that users of the library learn [Google Protocol Buffers](https://developers.google.com/protocol-buffers/) syntax to significantly ease usage. Understanding how to read Protocol Buffers, and reference [`gnmi.proto`](https://github.com/openconfig/gnmi/blob/master/proto/gnmi/gnmi.proto), will be immensely useful for utilizing gNMI and any other gRPC interface.
 
-### gnmcli
-Since `v1.0.5` a gNMI CLI is available when this module is installed. `Capabilities`, `Get`, rudimentary `Set`, and `Subscribe` are supported. The CLI may be useful for simply interacting with a Cisco gNMI service, and also serves as a reference for how to use this `cisco_gnmi` library. CLI usage is documented at the bottom of this README in [gnmcli Usage](#gnmcli-usage).
+### cisco-gnmi CLI
+Since `v1.0.5` a gNMI CLI is available as `cisco-gnmi` when this module is installed. `Capabilities`, `Get`, rudimentary `Set`, and `Subscribe` are supported. The CLI may be useful for simply interacting with a Cisco gNMI service, and also serves as a reference for how to use this `cisco_gnmi` library. CLI usage is documented at the bottom of this README in [CLI Usage](#cli-usage).
 
 ### ClientBuilder
 Since `v1.0.0` a builder pattern is available with `ClientBuilder`. `ClientBuilder` provides several `set_*` methods which define the intended `Client` connectivity and a `construct` method to construct and return the desired `Client`. There are several major methods involved here:
@@ -185,13 +185,13 @@ If a new `gnmi.proto` definition is released, use `update_protos.sh` to recompil
 ./update_protos.sh
 ```
 
-### gnmcli Usage
-The below details the current `gnmcli` usage options. Please note that `Set` operations may be destructive to operations and should be tested in lab conditions.
+### CLI Usage
+The below details the current `cisco-gnmi` usage options. Please note that `Set` operations may be destructive to operations and should be tested in lab conditions.
 
 ```
-gnmcli --help
+cisco-gnmi --help
 usage:
-gnmcli <rpc> [<args>]
+cisco-gnmi <rpc> [<args>]
 
 Supported RPCs:
 capabilities
@@ -199,10 +199,10 @@ subscribe
 get
 set
 
-gnmcli capabilities 127.0.0.1:57500
-gnmcli get 127.0.0.1:57500
-gnmcli set 127.0.0.1:57500 -delete_xpath Cisco-IOS-XR-shellutil-cfg:host-names/host-name
-gnmcli subscribe 127.0.0.1:57500 -debug -auto_ssl_target_override -dump_file intfcounters.proto.txt
+cisco-gnmi capabilities 127.0.0.1:57500
+cisco-gnmi get 127.0.0.1:57500
+cisco-gnmi set 127.0.0.1:57500 -delete_xpath Cisco-IOS-XR-shellutil-cfg:host-names/host-name
+cisco-gnmi subscribe 127.0.0.1:57500 -debug -auto_ssl_target_override -dump_file intfcounters.proto.txt
 
 See <rpc> --help for RPC options.
 
@@ -219,12 +219,12 @@ optional arguments:
 #### Capabilities
 This command will output the `CapabilitiesResponse` to `stdout`.
 ```
-gnmcli capabilities 127.0.0.1:57500 -auto_ssl_target_override
+cisco-gnmi capabilities 127.0.0.1:57500 -auto_ssl_target_override
 ```
 
 ```
-gnmcli capabilities --help
-usage: gnmcli [-h] [-os {None,IOS XR,NX-OS,IOS XE}]
+cisco-gnmi capabilities --help
+usage: cisco-gnmi [-h] [-os {None,IOS XR,NX-OS,IOS XE}]
               [-root_certificates ROOT_CERTIFICATES]
               [-private_key PRIVATE_KEY]
               [-certificate_chain CERTIFICATE_CHAIN]
@@ -258,11 +258,11 @@ optional arguments:
 #### Get
 This command will output the `GetResponse` to `stdout`. `-xpath` may be specified multiple times to specify multiple `Path`s for the `GetRequest`.
 ```
-gnmcli get 127.0.0.1:57500 -os "IOS XR" -xpath /interfaces/interface/state/counters -auto_ssl_target_override
+cisco-gnmi get 127.0.0.1:57500 -os "IOS XR" -xpath /interfaces/interface/state/counters -auto_ssl_target_override
 ```
 
 ```
-usage: gnmcli [-h] [-xpath XPATH]
+usage: cisco-gnmi [-h] [-xpath XPATH]
               [-encoding [{JSON,BYTES,PROTO,ASCII,JSON_IETF}]]
               [-data_type [{ALL,CONFIG,STATE,OPERATIONAL}]] [-dump_json]
               [-os {None,IOS XR,NX-OS,IOS XE}]
@@ -305,7 +305,7 @@ optional arguments:
 #### Set
 This command has not been validated. Please note that `Set` operations may be destructive to operations and should be tested in lab conditions.
 ```
-usage: gnmcli [-h] [-update_json_config UPDATE_JSON_CONFIG]
+usage: cisco-gnmi [-h] [-update_json_config UPDATE_JSON_CONFIG]
               [-replace_json_config REPLACE_JSON_CONFIG]
               [-delete_xpath DELETE_XPATH] [-no_ietf] [-dump_json]
               [-os {None,IOS XR,NX-OS,IOS XE}]
@@ -350,12 +350,12 @@ optional arguments:
 #### Subscribe
 This command will output the `SubscribeResponse` to `stdout` or `-dump_file`. `-xpath` may be specified multiple times to specify multiple `Path`s for the `GetRequest`. Subscribe currently only supports a sampled stream. `ON_CHANGE` is possible but not implemented in the CLI, yet. :)
 ```
-gnmcli subscribe 127.0.0.1:57500 -os "IOS XR" -xpath /interfaces/interface/state/counters -auto_ssl_target_override
+cisco-gnmi subscribe 127.0.0.1:57500 -os "IOS XR" -xpath /interfaces/interface/state/counters -auto_ssl_target_override
 ```
 
 ```
-gnmcli subscribe --help
-usage: gnmcli [-h] [-xpath XPATH] [-interval INTERVAL] [-dump_file DUMP_FILE]
+cisco-gnmi subscribe --help
+usage: cisco-gnmi [-h] [-xpath XPATH] [-interval INTERVAL] [-dump_file DUMP_FILE]
               [-dump_json] [-sync_stop]
               [-encoding [{JSON,BYTES,PROTO,ASCII,JSON_IETF}]]
               [-os {None,IOS XR,NX-OS,IOS XE}]

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ If a new `gnmi.proto` definition is released, use `update_protos.sh` to recompil
 ./update_protos.sh
 ```
 
-### gnmicli Usage
+### gnmcli Usage
 The below details the current `gnmcli` usage options.
 
 ```
@@ -212,6 +212,11 @@ optional arguments:
 ```
 
 #### Capabilities
+This command will output the `CapabilitiesResponse` to `stdout`.
+```
+gnmcli capabilities 127.0.0.1:57500 -auto_ssl_target_override
+```
+
 ```
 gnmcli capabilities --help
 usage: gnmcli [-h] [-os {None,IOS XR,NX-OS,IOS XE}]
@@ -245,6 +250,11 @@ optional arguments:
 ```
 
 #### Get
+This command will output the `GetResponse` to `stdout`. `-xpath` may be specified multiple times to specify multiple `Path`s for the `GetRequest`.
+```
+gnmcli get 127.0.0.1:57500 -os "IOS XR" -xpath /interfaces/interface/state/counters -auto_ssl_target_override
+```
+
 ```
 gnmcli get --help
 usage: gnmcli [-h] [-xpath XPATH]
@@ -287,7 +297,11 @@ optional arguments:
 ```
 
 #### Subscribe
-Subscribe currently only supports a sampled stream. `ON_CHANGE` is possible but not implemented in the CLI, yet. :)
+This command will output the `SubscribeResponse` to `stdout` or `-dump_file`. `-xpath` may be specified multiple times to specify multiple `Path`s for the `GetRequest`. Subscribe currently only supports a sampled stream. `ON_CHANGE` is possible but not implemented in the CLI, yet. :)
+```
+gnmcli subscribe 127.0.0.1:57500 -os "IOS XR" -xpath /interfaces/interface/state/counters -auto_ssl_target_override
+```
+
 ```
 gnmcli subscribe --help
 usage: gnmcli [-h] [-xpath XPATH] [-interval INTERVAL] [-dump_file DUMP_FILE]
@@ -331,6 +345,7 @@ optional arguments:
 ```
 
 #### Set
+This command has not been validated.
 ```
 gnmcli set --help
 usage: gnmcli [-h] [-update_json_config UPDATE_JSON_CONFIG]

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ This library wraps gNMI functionality to ease usage with Cisco implementations i
       - [Output](#output-1)
     - [Set](#set)
       - [Usage](#usage-3)
+      - [Output](#output-2)
     - [Subscribe](#subscribe)
       - [Usage](#usage-4)
-      - [Output](#output-2)
+      - [Output](#output-3)
   - [Licensing](#licensing)
   - [Issues](#issues)
   - [Related Projects](#related-projects)
@@ -376,7 +377,7 @@ INFO:root:notification {
 ```
 
 ### Set
-This command has not been validated. Please note that `Set` operations may be destructive to operations and should be tested in lab conditions.
+Please note that `Set` operations may be destructive to operations and should be tested in lab conditions. Behavior is not fully validated.
 
 #### Usage
 ```
@@ -420,6 +421,51 @@ optional arguments:
                         Use root_certificates first CN as
                         grpc.ssl_target_name_override.
   -debug                Print debug messages.
+```
+
+#### Output
+Let's create a harmless loopback interface based from [`openconfig-interfaces.yang`](https://github.com/openconfig/public/blob/master/release/models/interfaces/openconfig-interfaces.yang).
+
+`config.json`
+```json
+{
+    "openconfig-interfaces:interfaces": {
+        "interface": [
+            {
+                "name": "Loopback9339"
+            }
+        ]
+    }
+}
+```
+
+```
+[cisco-gnmi-python] cisco-gnmi set redacted:57500 -os "IOS XR" -auto_ssl_target_override -update_json_config config.json
+Username: admin
+Password:
+WARNING:root:Overriding SSL option from certificate could increase MITM susceptibility!
+INFO:root:response {
+  path {
+    origin: "openconfig-interfaces"
+    elem {
+      name: "interfaces"
+    }
+  }
+  message {
+  }
+  op: UPDATE
+}
+message {
+}
+timestamp: 1585715036783451369
+```
+
+And on IOS XR...a loopback interface!
+```
+...
+interface Loopback9339
+!
+...
 ```
 
 ### Subscribe

--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ This library wraps gNMI functionality to ease usage with Cisco implementations i
 ```bash
 pip install cisco-gnmi
 python -c "import cisco_gnmi; print(cisco_gnmi)"
+gnmcli --help
 ```
 
-This library covers the gNMI defined `capabilities`, `get`, `set`, and `subscribe` RPCs, and helper clients provide OS-specific recommendations. As commonalities and differences are identified this library will be refactored as necessary.
+This library covers the gNMI defined `Capabilities`, `Get`, `Set`, and `Subscribe` RPCs, and helper clients provide OS-specific recommendations. A CLI is also available. As commonalities and differences are identified between OS functionality this library will be refactored as necessary.
 
 It is *highly* recommended that users of the library learn [Google Protocol Buffers](https://developers.google.com/protocol-buffers/) syntax to significantly ease usage. Understanding how to read Protocol Buffers, and reference [`gnmi.proto`](https://github.com/openconfig/gnmi/blob/master/proto/gnmi/gnmi.proto), will be immensely useful for utilizing gNMI and any other gRPC interface.
+
+### gnmcli
+Since `v1.0.5` a gNMI CLI is available when this module is installed. `Capabilities`, `Subscribe`, `Get`, and rudimentary `Set` are supported. The CLI may be useful for simply interacting with a Cisco gNMI service, and also serves as a reference for how to use this `cisco_gnmi` library. CLI usage is documented at the bottom of this README in [gnmcli Usage](#gnmcli-usage).
 
 ### ClientBuilder
 Since `v1.0.0` a builder pattern is available with `ClientBuilder`. `ClientBuilder` provides several `set_*` methods which define the intended `Client` connectivity and a `construct` method to construct and return the desired `Client`. There are several major methods involved here:
@@ -179,6 +183,195 @@ If a new `gnmi.proto` definition is released, use `update_protos.sh` to recompil
 
 ```bash
 ./update_protos.sh
+```
+
+### gnmicli Usage
+The below details the current `gnmcli` usage options.
+
+```
+gnmcli --help
+usage:
+gnmcli <rpc> [<args>]
+
+Supported RPCs:
+capabilities
+subscribe
+get
+set
+
+See <rpc> --help for RPC options.
+
+
+gNMI CLI demonstrating library usage.
+
+positional arguments:
+  rpc         gNMI RPC to perform against network element.
+
+optional arguments:
+  -h, --help  show this help message and exit
+```
+
+#### Capabilities
+```
+gnmcli capabilities --help
+usage: gnmcli [-h] [-os {None,IOS XR,NX-OS,IOS XE}]
+              [-root_certificates ROOT_CERTIFICATES]
+              [-private_key PRIVATE_KEY]
+              [-certificate_chain CERTIFICATE_CHAIN]
+              [-ssl_target_override SSL_TARGET_OVERRIDE]
+              [-auto_ssl_target_override] [-debug]
+              netloc
+
+Performs Capabilities RPC against network element.
+
+positional arguments:
+  netloc                <host>:<port>
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -os {None,IOS XR,NX-OS,IOS XE}
+                        OS to use.
+  -root_certificates ROOT_CERTIFICATES
+                        Root certificates for secure connection.
+  -private_key PRIVATE_KEY
+                        Private key for secure connection.
+  -certificate_chain CERTIFICATE_CHAIN
+                        Certificate chain for secure connection.
+  -ssl_target_override SSL_TARGET_OVERRIDE
+                        gRPC SSL target override option.
+  -auto_ssl_target_override
+                        Root certificates for secure connection.
+  -debug                Print debug messages
+```
+
+#### Get
+```
+gnmcli get --help
+usage: gnmcli [-h] [-xpath XPATH]
+              [-encoding [{JSON,BYTES,PROTO,ASCII,JSON_IETF}]]
+              [-data_type [{ALL,CONFIG,STATE,OPERATIONAL}]] [-dump_json]
+              [-os {None,IOS XR,NX-OS,IOS XE}]
+              [-root_certificates ROOT_CERTIFICATES]
+              [-private_key PRIVATE_KEY]
+              [-certificate_chain CERTIFICATE_CHAIN]
+              [-ssl_target_override SSL_TARGET_OVERRIDE]
+              [-auto_ssl_target_override] [-debug]
+              netloc
+
+Performs Get RPC against network element.
+
+positional arguments:
+  netloc                <host>:<port>
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -xpath XPATH          XPaths to Get.
+  -encoding [{JSON,BYTES,PROTO,ASCII,JSON_IETF}]
+                        gNMI subscription encoding.
+  -data_type [{ALL,CONFIG,STATE,OPERATIONAL}]
+                        gNMI GetRequest DataType
+  -dump_json            Dump as JSON instead of textual protos.
+  -os {None,IOS XR,NX-OS,IOS XE}
+                        OS to use.
+  -root_certificates ROOT_CERTIFICATES
+                        Root certificates for secure connection.
+  -private_key PRIVATE_KEY
+                        Private key for secure connection.
+  -certificate_chain CERTIFICATE_CHAIN
+                        Certificate chain for secure connection.
+  -ssl_target_override SSL_TARGET_OVERRIDE
+                        gRPC SSL target override option.
+  -auto_ssl_target_override
+                        Root certificates for secure connection.
+  -debug                Print debug messages
+```
+
+#### Subscribe
+Subscribe currently only supports a sampled stream. `ON_CHANGE` is possible but not implemented in the CLI, yet. :)
+```
+gnmcli subscribe --help
+usage: gnmcli [-h] [-xpath XPATH] [-interval INTERVAL] [-dump_file DUMP_FILE]
+              [-dump_json] [-sync_stop]
+              [-encoding [{JSON,BYTES,PROTO,ASCII,JSON_IETF}]]
+              [-os {None,IOS XR,NX-OS,IOS XE}]
+              [-root_certificates ROOT_CERTIFICATES]
+              [-private_key PRIVATE_KEY]
+              [-certificate_chain CERTIFICATE_CHAIN]
+              [-ssl_target_override SSL_TARGET_OVERRIDE]
+              [-auto_ssl_target_override] [-debug]
+              netloc
+
+Performs Subscribe RPC against network element.
+
+positional arguments:
+  netloc                <host>:<port>
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -xpath XPATH          XPath to subscribe to.
+  -interval INTERVAL    Sample interval in seconds for Subscription.
+  -dump_file DUMP_FILE  Filename to dump to. Defaults to stdout.
+  -dump_json            Dump as JSON instead of textual protos.
+  -sync_stop            Stop on sync_response.
+  -encoding [{JSON,BYTES,PROTO,ASCII,JSON_IETF}]
+                        gNMI subscription encoding.
+  -os {None,IOS XR,NX-OS,IOS XE}
+                        OS to use.
+  -root_certificates ROOT_CERTIFICATES
+                        Root certificates for secure connection.
+  -private_key PRIVATE_KEY
+                        Private key for secure connection.
+  -certificate_chain CERTIFICATE_CHAIN
+                        Certificate chain for secure connection.
+  -ssl_target_override SSL_TARGET_OVERRIDE
+                        gRPC SSL target override option.
+  -auto_ssl_target_override
+                        Root certificates for secure connection.
+  -debug                Print debug messages
+```
+
+#### Set
+```
+gnmcli set --help
+usage: gnmcli [-h] [-update_json_config UPDATE_JSON_CONFIG]
+              [-replace_json_config REPLACE_JSON_CONFIG]
+              [-delete_xpath DELETE_XPATH] [-no_ietf] [-dump_json]
+              [-os {None,IOS XR,NX-OS,IOS XE}]
+              [-root_certificates ROOT_CERTIFICATES]
+              [-private_key PRIVATE_KEY]
+              [-certificate_chain CERTIFICATE_CHAIN]
+              [-ssl_target_override SSL_TARGET_OVERRIDE]
+              [-auto_ssl_target_override] [-debug]
+              netloc
+
+Performs Set RPC against network element.
+
+positional arguments:
+  netloc                <host>:<port>
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -update_json_config UPDATE_JSON_CONFIG
+                        JSON-modeled config to apply as an update.
+  -replace_json_config REPLACE_JSON_CONFIG
+                        JSON-modeled config to apply as an update.
+  -delete_xpath DELETE_XPATH
+                        XPaths to delete.
+  -no_ietf              JSON is not IETF conformant.
+  -dump_json            Dump as JSON instead of textual protos.
+  -os {None,IOS XR,NX-OS,IOS XE}
+                        OS to use.
+  -root_certificates ROOT_CERTIFICATES
+                        Root certificates for secure connection.
+  -private_key PRIVATE_KEY
+                        Private key for secure connection.
+  -certificate_chain CERTIFICATE_CHAIN
+                        Certificate chain for secure connection.
+  -ssl_target_override SSL_TARGET_OVERRIDE
+                        gRPC SSL target override option.
+  -auto_ssl_target_override
+                        Root certificates for secure connection.
+  -debug                Print debug messages
 ```
 
 ## Licensing

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,27 @@
+#!/usr/bin/env python
+"""Copyright 2020 Cisco Systems
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+
+The contents of this file are licensed under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+"""
+
 """Derived from Flask
 https://github.com/pallets/flask/blob/master/setup.py
 """

--- a/setup.py
+++ b/setup.py
@@ -69,5 +69,5 @@ setup(
             "coverage",
         ],
     },
-    entry_points={"console_scripts": ["gnmcli = cisco_gnmi.cli:main"]},
+    entry_points={"console_scripts": ["cisco-gnmi = cisco_gnmi.cli:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -69,4 +69,5 @@ setup(
             "coverage",
         ],
     },
+    entry_points={"console_scripts": ["gnmcli = cisco_gnmi.cli:main"]},
 )

--- a/src/cisco_gnmi/__init__.py
+++ b/src/cisco_gnmi/__init__.py
@@ -30,4 +30,4 @@ from .nx import NXClient
 from .xe import XEClient
 from .builder import ClientBuilder
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/src/cisco_gnmi/cli.py
+++ b/src/cisco_gnmi/cli.py
@@ -239,7 +239,7 @@ def gnmi_set():
         config = None
         with open(filename, "r") as config_fd:
             config = json.load(config_fd)
-        return config
+        return json.dumps(config)
 
     if args.update_json_config or args.replace_json_config:
         kwargs = {}

--- a/src/cisco_gnmi/cli.py
+++ b/src/cisco_gnmi/cli.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+"""
+Command parsing sourced from this wonderful blog by Chase Seibert
+https://chase-seibert.github.io/blog/2014/03/21/python-multilevel-argparse.html
+"""
+import json
+import logging
+import argparse
+from getpass import getpass
+from google.protobuf import json_format, text_format
+from . import ClientBuilder
+import sys
+
+
+def main():
+    # Using a map so we don't have function overlap e.g. set()
+    rpc_map = {
+        "capabilities": gnmi_capabilities,
+        "subscribe": gnmi_subscribe,
+        "get": gnmi_get,
+        "set": gnmi_set
+    }
+    parser = argparse.ArgumentParser(description="gNMI CLI demonstrating library usage.", usage="""
+    gnmcli <rpc> [<args>]
+
+    Supported RPCs:
+    %s
+
+    See --help for RPC options.
+    """.format('\n'.join(rpc_map.keys())))
+    parser.add_argument("rpc", help="gNMI RPC to perform against network element.")
+    if len(sys.argv) < 2:
+        logging.error("Must at minimum provide RPC and required arguments!")
+        parser.print_help()
+        exit(1)
+    args = parser.parse_args(sys.argv[1:2])
+    if args.rpc not in rpc_map.keys():
+        logging.error("%s not in supported RPCs: %s!", args.rpc, ', '.join(rpc_map.keys()))
+        parser.print_help()
+        exit(1)
+    rpc_map[args.rpc]()
+
+def gnmi_capabilities():
+    parser = argparse.ArgumentParser(
+        description="Performs Capabilities RPC against network element."
+    )
+    args = __common_args_handler(parser)
+
+def gnmi_subscribe():
+    parser = argparse.ArgumentParser(
+        description="Performs Subscribe RPC against network element."
+    )
+    args = __common_args_handler(parser)
+    pass
+
+def gnmi_get():
+    parser = argparse.ArgumentParser(
+        description="Performs Get RPC against network element."
+    )
+    args = __common_args_handler(parser)
+
+def gnmi_set():
+    parser = argparse.ArgumentParser(
+        description="Performs Set RPC against network element."
+    )
+    args = __common_args_handler(parser)
+
+def __gen_client(netloc, os_name, username, password, root_certificates=None, private_key=None, certificate_chain=None, ssl_target_override=None, auto_ssl_target_override=False):
+    builder = ClientBuilder(netloc)
+    builder.set_os(os_name)
+    builder.set_call_authentication(username, password)
+    if not any([root_certificates, private_key, certificate_chain]):
+        builder.set_secure_from_target()
+    else:
+        builder.set_secure_from_file(root_certificates, private_key, certificate_chain)
+    if ssl_target_override:
+        builder.set_ssl_target_override(ssl_target_override)
+    elif auto_ssl_target_override:
+        builder.set_ssl_target_override()
+    return builder.construct()
+
+def __common_args_handler(parser):
+    """Ideally would be a decorator."""
+    parser.add_argument("netloc", help="<host>:<port>", type=str)
+    parser.add_argument(
+        "-os",
+        help="OS to use.",
+        type=str,
+        default="IOS XR",
+        choices=list(ClientBuilder.os_class_map.keys()),
+    )
+    parser.add_argument("-root_certificates", description="Root certificates for secure connection.")
+    parser.add_argument("-private_key", description="Private key for secure connection.")
+    parser.add_argument("-certificate_chain", description="Certificate chain for secure connection.")
+    parser.add_argument("-ssl_target_override", description="gRPC SSL target override option.")
+    parser.add_argument("-auto_ssl_target_override", description="Root certificates for secure connection.", action="store_true")
+    parser.add_argument("-debug", help="Print debug messages", action="store_true")
+    args = parser.parse_args(sys.argv[2:])
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+    args.username = input("Username: ")
+    args.password = getpass()
+    return args
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cisco_gnmi/cli.py
+++ b/src/cisco_gnmi/cli.py
@@ -48,17 +48,17 @@ def main():
         "set": gnmi_set,
     }
     parser = argparse.ArgumentParser(
-        description="gNMI CLI demonstrating library usage.",
+        description="gNMI CLI demonstrating cisco_gnmi library usage.",
         usage="""
-gnmcli <rpc> [<args>]
+cisco-gnmi <rpc> [<args>]
 
 Supported RPCs:
 {supported_rpcs}
 
-gnmcli capabilities 127.0.0.1:57500
-gnmcli get 127.0.0.1:57500 -xpath /interfaces/interface/state/counters
-gnmcli set 127.0.0.1:57500 -update_json_config newconfig.json
-gnmcli subscribe 127.0.0.1:57500 -xpath /interfaces/interface/state/counters -dump_file intfcounters.proto.txt
+cisco-gnmi capabilities 127.0.0.1:57500
+cisco-gnmi get 127.0.0.1:57500 -xpath /interfaces/interface/state/counters
+cisco-gnmi set 127.0.0.1:57500 -update_json_config newconfig.json
+cisco-gnmi subscribe 127.0.0.1:57500 -xpath /interfaces/interface/state/counters -dump_file intfcounters.proto.txt
 
 See <rpc> --help for RPC options.
     """.format(

--- a/src/cisco_gnmi/cli.py
+++ b/src/cisco_gnmi/cli.py
@@ -211,10 +211,10 @@ def gnmi_set():
         description="Performs Set RPC against network element."
     )
     parser.add_argument(
-        "-update_json_config", description="JSON-modeled config to apply as an update."
+        "-update_json_config", help="JSON-modeled config to apply as an update."
     )
     parser.add_argument(
-        "-replace_json_config", description="JSON-modeled config to apply as an update."
+        "-replace_json_config", help="JSON-modeled config to apply as an update."
     )
     parser.add_argument(
         "-delete_xpath", help="XPaths to delete.", type=str, action="append"

--- a/src/cisco_gnmi/cli.py
+++ b/src/cisco_gnmi/cli.py
@@ -1,7 +1,30 @@
 #!/usr/bin/env python
+"""Copyright 2020 Cisco Systems
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+
+The contents of this file are licensed under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+"""
+
 """
 Wraps gNMI RPCs with a reasonably useful CLI for interacting with network elements.
-
+Supports Capabilities, Subscribe, Get, and Set.
 
 Command parsing sourced from this wonderful blog by Chase Seibert
 https://chase-seibert.github.io/blog/2014/03/21/python-multilevel-argparse.html

--- a/src/cisco_gnmi/cli.py
+++ b/src/cisco_gnmi/cli.py
@@ -166,7 +166,6 @@ def gnmi_subscribe():
 
 def gnmi_get():
     """Provides Get RPC usage. Assumes JSON or JSON_IETF style configurations.
-    TODO: This is the least well understood/implemented. Need to validate if there is an OOO for update/replace/delete.
     """
     parser = argparse.ArgumentParser(
         description="Performs Get RPC against network element."

--- a/src/cisco_gnmi/client.py
+++ b/src/cisco_gnmi/client.py
@@ -152,7 +152,7 @@ class Client(object):
             "encoding", encoding, "Encoding", proto.gnmi_pb2.Encoding
         )
         request = proto.gnmi_pb2.GetRequest()
-        if not isinstance(paths, (list, set)):
+        if not isinstance(paths, (list, set, map)):
             raise Exception("paths must be an iterable containing Path(s)!")
         request.path.extend(paths)
         request.type = data_type


### PR DESCRIPTION
Inspired by `flask`. Adds a `cisco-gnmi` command supporting usage of `Capabilities`, `Get`, `Set` and `Subscribe`. ~`Set` has not been properly tested and should gate this pull request. Opening for the sake of review.~

Related to #40 
Fixes #37 