### PR TITLE
Refactor subscribe_xpaths into base Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,12 +257,12 @@ cisco-gnmi capabilities 127.0.0.1:57500 -auto_ssl_target_override
 ```
 cisco-gnmi capabilities --help
 usage: cisco-gnmi [-h] [-os {None,IOS XR,NX-OS,IOS XE}]
-              [-root_certificates ROOT_CERTIFICATES]
-              [-private_key PRIVATE_KEY]
-              [-certificate_chain CERTIFICATE_CHAIN]
-              [-ssl_target_override SSL_TARGET_OVERRIDE]
-              [-auto_ssl_target_override] [-debug]
-              netloc
+                  [-root_certificates ROOT_CERTIFICATES]
+                  [-private_key PRIVATE_KEY]
+                  [-certificate_chain CERTIFICATE_CHAIN]
+                  [-ssl_target_override SSL_TARGET_OVERRIDE]
+                  [-auto_ssl_target_override] [-debug]
+                  netloc
 
 Performs Capabilities RPC against network element.
 
@@ -309,16 +309,17 @@ cisco-gnmi get 127.0.0.1:57500 -os "IOS XR" -xpath /interfaces/interface/state/c
 
 #### Usage
 ```
+cisco-gnmi get --help
 usage: cisco-gnmi [-h] [-xpath XPATH]
-              [-encoding [{JSON,BYTES,PROTO,ASCII,JSON_IETF}]]
-              [-data_type [{ALL,CONFIG,STATE,OPERATIONAL}]] [-dump_json]
-              [-os {None,IOS XR,NX-OS,IOS XE}]
-              [-root_certificates ROOT_CERTIFICATES]
-              [-private_key PRIVATE_KEY]
-              [-certificate_chain CERTIFICATE_CHAIN]
-              [-ssl_target_override SSL_TARGET_OVERRIDE]
-              [-auto_ssl_target_override] [-debug]
-              netloc
+                  [-encoding {JSON,BYTES,PROTO,ASCII,JSON_IETF}]
+                  [-data_type {ALL,CONFIG,STATE,OPERATIONAL}] [-dump_json]
+                  [-os {None,IOS XR,NX-OS,IOS XE}]
+                  [-root_certificates ROOT_CERTIFICATES]
+                  [-private_key PRIVATE_KEY]
+                  [-certificate_chain CERTIFICATE_CHAIN]
+                  [-ssl_target_override SSL_TARGET_OVERRIDE]
+                  [-auto_ssl_target_override] [-debug]
+                  netloc
 
 Performs Get RPC against network element.
 
@@ -328,9 +329,9 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -xpath XPATH          XPaths to Get.
-  -encoding [{JSON,BYTES,PROTO,ASCII,JSON_IETF}]
+  -encoding {JSON,BYTES,PROTO,ASCII,JSON_IETF}
                         gNMI Encoding.
-  -data_type [{ALL,CONFIG,STATE,OPERATIONAL}]
+  -data_type {ALL,CONFIG,STATE,OPERATIONAL}
                         gNMI GetRequest DataType
   -dump_json            Dump as JSON instead of textual protos.
   -os {None,IOS XR,NX-OS,IOS XE}
@@ -381,16 +382,17 @@ Please note that `Set` operations may be destructive to operations and should be
 
 #### Usage
 ```
+cisco-gnmi set --help
 usage: cisco-gnmi [-h] [-update_json_config UPDATE_JSON_CONFIG]
-              [-replace_json_config REPLACE_JSON_CONFIG]
-              [-delete_xpath DELETE_XPATH] [-no_ietf] [-dump_json]
-              [-os {None,IOS XR,NX-OS,IOS XE}]
-              [-root_certificates ROOT_CERTIFICATES]
-              [-private_key PRIVATE_KEY]
-              [-certificate_chain CERTIFICATE_CHAIN]
-              [-ssl_target_override SSL_TARGET_OVERRIDE]
-              [-auto_ssl_target_override] [-debug]
-              netloc
+                  [-replace_json_config REPLACE_JSON_CONFIG]
+                  [-delete_xpath DELETE_XPATH] [-no_ietf] [-dump_json]
+                  [-os {None,IOS XR,NX-OS,IOS XE}]
+                  [-root_certificates ROOT_CERTIFICATES]
+                  [-private_key PRIVATE_KEY]
+                  [-certificate_chain CERTIFICATE_CHAIN]
+                  [-ssl_target_override SSL_TARGET_OVERRIDE]
+                  [-auto_ssl_target_override] [-debug]
+                  netloc
 
 Performs Set RPC against network element.
 
@@ -469,7 +471,8 @@ interface Loopback9339
 ```
 
 ### Subscribe
-This command will output the `SubscribeResponse` to `stdout` or `-dump_file`. `-xpath` may be specified multiple times to specify multiple `Path`s for the `GetRequest`. Subscribe currently only supports a sampled stream. `ON_CHANGE` is possible but not implemented in the CLI, yet. :)
+This command will output the `SubscribeResponse` to `stdout` or `-dump_file`. `-xpath` may be specified multiple times to specify multiple `Path`s for the `GetRequest`.
+
 ```
 cisco-gnmi subscribe 127.0.0.1:57500 -os "IOS XR" -xpath /interfaces/interface/state/counters -auto_ssl_target_override
 ```
@@ -477,16 +480,19 @@ cisco-gnmi subscribe 127.0.0.1:57500 -os "IOS XR" -xpath /interfaces/interface/s
 #### Usage
 ```
 cisco-gnmi subscribe --help
-usage: cisco-gnmi [-h] [-xpath XPATH] [-interval INTERVAL] [-dump_file DUMP_FILE]
-              [-dump_json] [-sync_stop]
-              [-encoding [{JSON,BYTES,PROTO,ASCII,JSON_IETF}]]
-              [-os {None,IOS XR,NX-OS,IOS XE}]
-              [-root_certificates ROOT_CERTIFICATES]
-              [-private_key PRIVATE_KEY]
-              [-certificate_chain CERTIFICATE_CHAIN]
-              [-ssl_target_override SSL_TARGET_OVERRIDE]
-              [-auto_ssl_target_override] [-debug]
-              netloc
+usage: cisco-gnmi [-h] [-xpath XPATH] [-interval INTERVAL]
+                  [-mode {TARGET_DEFINED,ON_CHANGE,SAMPLE}]
+                  [-suppress_redundant]
+                  [-heartbeat_interval HEARTBEAT_INTERVAL]
+                  [-dump_file DUMP_FILE] [-dump_json] [-sync_stop]
+                  [-sync_start] [-encoding {JSON,BYTES,PROTO,ASCII,JSON_IETF}]
+                  [-os {None,IOS XR,NX-OS,IOS XE}]
+                  [-root_certificates ROOT_CERTIFICATES]
+                  [-private_key PRIVATE_KEY]
+                  [-certificate_chain CERTIFICATE_CHAIN]
+                  [-ssl_target_override SSL_TARGET_OVERRIDE]
+                  [-auto_ssl_target_override] [-debug]
+                  netloc
 
 Performs Subscribe RPC against network element.
 
@@ -498,11 +504,18 @@ optional arguments:
   -xpath XPATH          XPath to subscribe to.
   -interval INTERVAL    Sample interval in seconds for Subscription. Defaults
                         to 10.
+  -mode {TARGET_DEFINED,ON_CHANGE,SAMPLE}
+                        SubscriptionMode for Subscription. Defaults to SAMPLE.
+  -suppress_redundant   Suppress redundant information in Subscription.
+  -heartbeat_interval HEARTBEAT_INTERVAL
+                        Heartbeat interval in seconds.
   -dump_file DUMP_FILE  Filename to dump to. Defaults to stdout.
   -dump_json            Dump as JSON instead of textual protos.
   -sync_stop            Stop on sync_response.
-  -encoding [{JSON,BYTES,PROTO,ASCII,JSON_IETF}]
-                        gNMI Encoding.
+  -sync_start           Start processing messages after sync_response.
+  -encoding {JSON,BYTES,PROTO,ASCII,JSON_IETF}
+                        gNMI Encoding. Defaults to whatever Client wrapper
+                        prefers.
   -os {None,IOS XR,NX-OS,IOS XE}
                         OS wrapper to utilize. Defaults to IOS XR.
   -root_certificates ROOT_CERTIFICATES

--- a/scripts/gen_certs.sh
+++ b/scripts/gen_certs.sh
@@ -40,7 +40,7 @@ if [ ! -z $password ]; then
     openssl rsa -des3 -in $CERT_BASE/device.key -out $CERT_BASE/device.des3.key -passout pass:$password
     # PKCS #12 for device, needed for NX-OS
     # Uncertain if this is correct
-    openssl pkcs12 -export -out $CERT_BASE/device.pfx -inkey $CERT_BASE/device.key -in $CERT_BASE/device.crt -certfile $CERT_BASE/device.crt -password pass:$password
+    openssl pkcs12 -export -out $CERT_BASE/device.pfx -inkey $CERT_BASE/device.key -in $CERT_BASE/device.crt -certfile $CERT_BASE/rootCA.pem -password pass:$password
 else
     print_red "SKIPPING device key encryption"
 fi

--- a/scripts/gen_certs.sh
+++ b/scripts/gen_certs.sh
@@ -19,31 +19,39 @@ function print_red () {
 }
 
 # Setting up a CA
-print_red "Generating rootCA"
-openssl genrsa -out $CERT_BASE/rootCA.key 2048
-openssl req -subj /C=/ST=/L=/O=/CN=rootCA -x509 -new -nodes -key $CERT_BASE/rootCA.key -sha256 -days 1095 -out $CERT_BASE/rootCA.pem
+if [ -f "$CERT_BASE/rootCA.key" ] && [ -f "$CERT_BASE/rootCA.pem" ]; then
+    print_red "SKIPPING rootCA generation, already exist"
+else
+    print_red "GENERATING rootCA"
+    openssl genrsa -out $CERT_BASE/rootCA.key 2048
+    openssl req -subj /C=/ST=/L=/O=/CN=rootCA -x509 -new -nodes -key $CERT_BASE/rootCA.key -sha256 -days 1095 -out $CERT_BASE/rootCA.pem
+fi
 
 # Setting up device cert and key
-print_red "Generating device certificates with CN $server_hostname and IP $ip"
+print_red "GENERATING device certificates with CN $server_hostname and IP $ip"
 openssl genrsa -out $CERT_BASE/device.key 2048
 openssl req -subj /C=/ST=/L=/O=/CN=$server_hostname -new -key $CERT_BASE/device.key -out $CERT_BASE/device.csr
 openssl x509 -req -in $CERT_BASE/device.csr -CA $CERT_BASE/rootCA.pem -CAkey $CERT_BASE/rootCA.key -CAcreateserial -out $CERT_BASE/device.crt -days 1095 -sha256 -extfile <(printf "%s" "subjectAltName=DNS:$server_hostname,IP:$ip")
 
 # Encrypt device key
 if [ ! -z $password ]; then
-    print_red "Encrypting device certificates and bundling with password"
+    print_red "ENCRYPTING device certificates and bundling with password"
     # DES 3 for device, needed for input to IOS XE
     openssl rsa -des3 -in $CERT_BASE/device.key -out $CERT_BASE/device.des3.key -passout pass:$password
     # PKCS #12 for device, needed for NX-OS
     # Uncertain if this is correct
     openssl pkcs12 -export -out $CERT_BASE/device.pfx -inkey $CERT_BASE/device.key -in $CERT_BASE/device.crt -certfile $CERT_BASE/device.crt -password pass:$password
 else
-    print_red "Skipping device key encryption"
+    print_red "SKIPPING device key encryption"
 fi
 
 # Setting up client cert and key
-hostname=$(hostname)
-print_red "Generating client certificates with CN $hostname"
-openssl genrsa -out $CERT_BASE/client.key 2048
-openssl req -subj /C=/ST=/L=/O=/CN=$hostname -new -key $CERT_BASE/client.key -out $CERT_BASE/client.csr
-openssl x509 -req -in $CERT_BASE/client.csr -CA $CERT_BASE/rootCA.pem -CAkey $CERT_BASE/rootCA.key -CAcreateserial -out $CERT_BASE/client.crt -days 1095 -sha256
+if [ -f "$CERT_BASE/client.key" ] && [ -f "$CERT_BASE/client.crt" ]; then
+    print_red "SKIPPING client certificates generation, already exist"
+else
+    hostname=$(hostname)
+    print_red "GENERATING client certificates with CN $hostname"
+    openssl genrsa -out $CERT_BASE/client.key 2048
+    openssl req -subj /C=/ST=/L=/O=/CN=$hostname -new -key $CERT_BASE/client.key -out $CERT_BASE/client.csr
+    openssl x509 -req -in $CERT_BASE/client.csr -CA $CERT_BASE/rootCA.pem -CAkey $CERT_BASE/rootCA.key -CAcreateserial -out $CERT_BASE/client.crt -days 1095 -sha256
+fi

--- a/src/cisco_gnmi/__init__.py
+++ b/src/cisco_gnmi/__init__.py
@@ -30,4 +30,4 @@ from .nx import NXClient
 from .xe import XEClient
 from .builder import ClientBuilder
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"

--- a/src/cisco_gnmi/cli.py
+++ b/src/cisco_gnmi/cli.py
@@ -34,7 +34,7 @@ import logging
 import argparse
 from getpass import getpass
 from google.protobuf import json_format, text_format
-from . import ClientBuilder, proto
+from . import ClientBuilder, proto, __version__
 from google.protobuf.internal import enum_type_wrapper
 import sys
 
@@ -52,6 +52,8 @@ def main():
         usage="""
 cisco-gnmi <rpc> [<args>]
 
+Version {version}
+
 Supported RPCs:
 {supported_rpcs}
 
@@ -62,7 +64,8 @@ cisco-gnmi subscribe 127.0.0.1:57500 -xpath /interfaces/interface/state/counters
 
 See <rpc> --help for RPC options.
     """.format(
-            supported_rpcs="\n".join(list(rpc_map.keys()))
+            version=__version__,
+            supported_rpcs="\n".join(sorted(list(rpc_map.keys())))
         ),
     )
     parser.add_argument("rpc", help="gNMI RPC to perform against network element.")

--- a/src/cisco_gnmi/nx.py
+++ b/src/cisco_gnmi/nx.py
@@ -157,7 +157,9 @@ class NXClient(Client):
                 "OpenConfig data models not yet supported on NX-OS!"
             )
         if origin is None:
-            if any(map(xpath.startswith, ["Cisco-NX-OS-device", "ietf-interfaces"])):
+            if any(
+                map(xpath.startswith, ["Cisco-NX-OS-device", "/Cisco-NX-OS-device"])
+            ):
                 origin = "device"
                 # Remove the module
                 xpath = xpath.split(":", 1)[1]

--- a/src/cisco_gnmi/nx.py
+++ b/src/cisco_gnmi/nx.py
@@ -66,6 +66,8 @@ class NXClient(Client):
         sub_mode="SAMPLE",
         encoding="PROTO",
         sample_interval=Client._NS_IN_S * 10,
+        suppress_redundant=False,
+        heartbeat_interval=None,
     ):
         """A convenience wrapper of subscribe() which aids in building of SubscriptionRequest
         with request as subscribe SubscriptionList. This method accepts an iterable of simply xpath strings,
@@ -98,75 +100,57 @@ class NXClient(Client):
         sample_interval : int, optional
             Default nanoseconds for sample to occur.
             Defaults to 10 seconds.
+        suppress_redundant : bool, optional
+            Indicates whether values that have not changed should be sent in a SAMPLE subscription.
+        heartbeat_interval : int, optional
+            Specifies the maximum allowable silent period in nanoseconds when
+            suppress_redundant is in use. The target should send a value at least once
+            in the period specified.
 
         Returns
         -------
         subscribe()
         """
         supported_request_modes = ["STREAM", "ONCE", "POLL"]
-        supported_encodings = ["JSON", "PROTO"]
-        supported_sub_modes = ["ON_CHANGE", "SAMPLE"]
-        subscription_list = proto.gnmi_pb2.SubscriptionList()
-        subscription_list.mode = util.validate_proto_enum(
+        request_mode = util.validate_proto_enum(
             "mode",
             request_mode,
             "SubscriptionList.Mode",
             proto.gnmi_pb2.SubscriptionList.Mode,
-            supported_request_modes,
+            subset=supported_request_modes,
+            return_name=True,
         )
-        subscription_list.encoding = util.validate_proto_enum(
+        supported_encodings = ["JSON", "PROTO"]
+        encoding = util.validate_proto_enum(
             "encoding",
             encoding,
             "Encoding",
             proto.gnmi_pb2.Encoding,
-            supported_encodings,
+            subset=supported_encodings,
+            return_name=True,
         )
-        if isinstance(xpath_subscriptions, string_types):
-            xpath_subscriptions = [xpath_subscriptions]
-        subscriptions = []
-        for xpath_subscription in xpath_subscriptions:
-            subscription = None
-            if isinstance(xpath_subscription, string_types):
-                subscription = proto.gnmi_pb2.Subscription()
-                subscription.path.CopyFrom(
-                    self.parse_xpath_to_gnmi_path(xpath_subscription)
-                )
-                subscription.mode = util.validate_proto_enum(
-                    "sub_mode",
-                    sub_mode,
-                    "SubscriptionMode",
-                    proto.gnmi_pb2.SubscriptionMode,
-                    supported_sub_modes,
-                )
-                subscription.sample_interval = sample_interval
-            elif isinstance(xpath_subscription, dict):
-                path = self.parse_xpath_to_gnmi_path(xpath_subscription["path"])
-                arg_dict = {
-                    "path": path,
-                    "mode": sub_mode,
-                    "sample_interval": sample_interval,
-                }
-                arg_dict.update(xpath_subscription)
-                if "mode" in arg_dict:
-                    arg_dict["mode"] = util.validate_proto_enum(
-                        "sub_mode",
-                        arg_dict["mode"],
-                        "SubscriptionMode",
-                        proto.gnmi_pb2.SubscriptionMode,
-                        supported_sub_modes,
-                    )
-                subscription = proto.gnmi_pb2.Subscription(**arg_dict)
-            elif isinstance(xpath_subscription, proto.gnmi_pb2.Subscription):
-                subscription = xpath_subscription
-            else:
-                raise Exception("xpath in list must be xpath or dict/Path!")
-            subscriptions.append(subscription)
-        subscription_list.subscription.extend(subscriptions)
-        return self.subscribe([subscription_list])
+        supported_sub_modes = ["ON_CHANGE", "SAMPLE"]
+        sub_mode = util.validate_proto_enum(
+            "sub_mode",
+            sub_mode,
+            "SubscriptionMode",
+            proto.gnmi_pb2.SubscriptionMode,
+            subset=supported_sub_modes,
+            return_name=True,
+        )
+        return super(NXClient, self).subscribe_xpaths(
+            xpath_subscriptions,
+            request_mode,
+            sub_mode,
+            encoding,
+            sample_interval,
+            suppress_redundant,
+            heartbeat_interval,
+        )
 
     def parse_xpath_to_gnmi_path(self, xpath, origin=None):
-        """Origin defaults to YANG (device) paths
-        Otherwise specify "DME" as origin
+        """Attempts to determine whether origin should be YANG (device) or DME.
+        Errors on OpenConfig until support is present.
         """
         if xpath.startswith("openconfig"):
             raise NotImplementedError(
@@ -175,6 +159,8 @@ class NXClient(Client):
         if origin is None:
             if any(map(xpath.startswith, ["Cisco-NX-OS-device", "ietf-interfaces"])):
                 origin = "device"
+                # Remove the module
+                xpath = xpath.split(":", 1)[1]
             else:
                 origin = "DME"
         return super(NXClient, self).parse_xpath_to_gnmi_path(xpath, origin)

--- a/src/cisco_gnmi/util.py
+++ b/src/cisco_gnmi/util.py
@@ -60,7 +60,9 @@ def gen_target_netloc(target, netloc_prefix="//", default_port=9339):
     return target_netloc
 
 
-def validate_proto_enum(value_name, value, enum_name, enum, subset=None):
+def validate_proto_enum(
+    value_name, value, enum_name, enum, subset=None, return_name=False
+):
     """Helper function to validate an enum against the proto enum wrapper."""
     enum_value = None
     if value not in enum.keys() and value not in enum.values():
@@ -91,11 +93,15 @@ def validate_proto_enum(value_name, value, enum_name, enum, subset=None):
                 )
         if enum_value not in resolved_subset:
             raise Exception(
-                "{name}={value} not in subset {subset}!".format(
-                    name=value_name, value=enum_value, subset=resolved_subset
+                "{name}={value} ({actual_value}) not in subset {subset} ({actual_subset})!".format(
+                    name=value_name,
+                    value=value,
+                    actual_value=enum_value,
+                    subset=subset,
+                    actual_subset=resolved_subset,
                 )
             )
-    return enum_value
+    return enum_value if not return_name else enum.Name(enum_value)
 
 
 def get_cert_from_target(target_netloc):

--- a/src/cisco_gnmi/xe.py
+++ b/src/cisco_gnmi/xe.py
@@ -214,8 +214,11 @@ class XEClient(Client):
     def subscribe_xpaths(
         self,
         xpath_subscriptions,
+        request_mode="STREAM",
+        sub_mode="SAMPLE",
         encoding="JSON_IETF",
         sample_interval=Client._NS_IN_S * 10,
+        suppress_redundant=False,
         heartbeat_interval=None,
     ):
         """A convenience wrapper of subscribe() which aids in building of SubscriptionRequest
@@ -233,12 +236,21 @@ class XEClient(Client):
             to SubscriptionRequest. Strings are parsed as XPaths and defaulted with the default arguments,
             dictionaries are treated as dicts of args to pass to the Subscribe init, and Subscription is
             treated as simply a pre-made Subscription.
+        request_mode : proto.gnmi_pb2.SubscriptionList.Mode, optional
+            Indicates whether STREAM to stream from target.
+            [STREAM]
+        sub_mode : proto.gnmi_pb2.SubscriptionMode, optional
+            The default SubscriptionMode on a per Subscription basis in the SubscriptionList.
+            SAMPLE will stream the subscription at a regular cadence/interval.
+            [SAMPLE]
         encoding : proto.gnmi_pb2.Encoding, optional
             A member of the proto.gnmi_pb2.Encoding enum specifying desired encoding of returned data
-            [JSON, JSON_IETF]
+            [JSON_IETF]
         sample_interval : int, optional
             Default nanoseconds for sample to occur.
             Defaults to 10 seconds.
+        suppress_redundant : bool, optional
+            Indicates whether values that have not changed should be sent in a SAMPLE subscription.
         heartbeat_interval : int, optional
             Specifies the maximum allowable silent period in nanoseconds when
             suppress_redundant is in use. The target should send a value at least once
@@ -249,67 +261,41 @@ class XEClient(Client):
         subscribe()
         """
         supported_request_modes = ["STREAM"]
-        request_mode = "STREAM"
-        supported_sub_modes = ["SAMPLE"]
-        sub_mode = "SAMPLE"
-        supported_encodings = ["JSON", "JSON_IETF"]
-        subscription_list = proto.gnmi_pb2.SubscriptionList()
-        subscription_list.mode = util.validate_proto_enum(
+        request_mode = util.validate_proto_enum(
             "mode",
             request_mode,
             "SubscriptionList.Mode",
             proto.gnmi_pb2.SubscriptionList.Mode,
-            supported_request_modes,
+            subset=supported_request_modes,
+            return_name=True,
         )
-        subscription_list.encoding = util.validate_proto_enum(
+        supported_encodings = ["JSON_IETF"]
+        encoding = util.validate_proto_enum(
             "encoding",
             encoding,
             "Encoding",
             proto.gnmi_pb2.Encoding,
-            supported_encodings,
+            subset=supported_encodings,
+            return_name=True,
         )
-        if isinstance(xpath_subscriptions, string_types):
-            xpath_subscriptions = [xpath_subscriptions]
-        subscriptions = []
-        for xpath_subscription in xpath_subscriptions:
-            subscription = None
-            if isinstance(xpath_subscription, string_types):
-                subscription = proto.gnmi_pb2.Subscription()
-                subscription.path.CopyFrom(
-                    self.parse_xpath_to_gnmi_path(xpath_subscription)
-                )
-                subscription.mode = util.validate_proto_enum(
-                    "sub_mode",
-                    sub_mode,
-                    "SubscriptionMode",
-                    proto.gnmi_pb2.SubscriptionMode,
-                    supported_sub_modes,
-                )
-                subscription.sample_interval = sample_interval
-            elif isinstance(xpath_subscription, dict):
-                path = self.parse_xpath_to_gnmi_path(xpath_subscription["path"])
-                arg_dict = {
-                    "path": path,
-                    "mode": sub_mode,
-                    "sample_interval": sample_interval,
-                }
-                arg_dict.update(xpath_subscription)
-                if "mode" in arg_dict:
-                    arg_dict["mode"] = util.validate_proto_enum(
-                        "sub_mode",
-                        arg_dict["mode"],
-                        "SubscriptionMode",
-                        proto.gnmi_pb2.SubscriptionMode,
-                        supported_sub_modes,
-                    )
-                subscription = proto.gnmi_pb2.Subscription(**arg_dict)
-            elif isinstance(xpath_subscription, proto.gnmi_pb2.Subscription):
-                subscription = xpath_subscription
-            else:
-                raise Exception("xpath in list must be xpath or dict/Path!")
-            subscriptions.append(subscription)
-        subscription_list.subscription.extend(subscriptions)
-        return self.subscribe([subscription_list])
+        supported_sub_modes = ["SAMPLE"]
+        sub_mode = util.validate_proto_enum(
+            "sub_mode",
+            sub_mode,
+            "SubscriptionMode",
+            proto.gnmi_pb2.SubscriptionMode,
+            subset=supported_sub_modes,
+            return_name=True,
+        )
+        return super(XEClient, self).subscribe_xpaths(
+            xpath_subscriptions,
+            request_mode,
+            sub_mode,
+            encoding,
+            sample_interval,
+            suppress_redundant,
+            heartbeat_interval,
+        )
 
     def parse_xpath_to_gnmi_path(self, xpath, origin=None):
         """Naively tries to intelligently (non-sequitur!) origin

--- a/src/cisco_gnmi/xr.py
+++ b/src/cisco_gnmi/xr.py
@@ -346,6 +346,7 @@ class XRClient(Client):
             else:
                 # module name
                 origin, xpath = xpath.split(":", 1)
+                origin = origin.strip("/")
         return super(XRClient, self).parse_xpath_to_gnmi_path(xpath, origin)
 
     def parse_cli_to_gnmi_path(self, command):


### PR DESCRIPTION
`subscribe_xpaths` is a common function across every OS and thus can be brought in to `Client`. This also enables usage by non-wrapper classes for validation of other OSes. Resolves #47

Side effects:
* Better certificate generation logic across IOS XE, IOS XR, and NX-OS.
* Add version to CLI output.
* Add some more CLI options in subscribe RPC.