### PR TITLE
Expose gRPC Channel in Client and ClientBuilder

### DIFF
--- a/src/cisco_gnmi/__init__.py
+++ b/src/cisco_gnmi/__init__.py
@@ -30,4 +30,4 @@ from .nx import NXClient
 from .xe import XEClient
 from .builder import ClientBuilder
 
-__version__ = "1.0.9"
+__version__ = "1.0.10"

--- a/src/cisco_gnmi/builder.py
+++ b/src/cisco_gnmi/builder.py
@@ -267,7 +267,7 @@ class ClientBuilder(object):
                 self.__channel_options.append(new_option)
         return self
 
-    def construct(self):
+    def construct(self, return_channel=False):
         """Constructs and returns the desired Client object.
         The instance of this class will reset to default values for further building.
 
@@ -315,7 +315,10 @@ class ClientBuilder(object):
             self.set_os()
         client = self.__client_class(channel)
         self._reset()
-        return client
+        if return_channel:
+            return client, channel
+        else:
+            return client
 
     def _reset(self):
         """Resets the builder.

--- a/src/cisco_gnmi/client.py
+++ b/src/cisco_gnmi/client.py
@@ -99,6 +99,7 @@ class Client(object):
             Timeout for gRPC functionality.
         """
         self.service = proto.gnmi_pb2_grpc.gNMIStub(grpc_channel)
+        self._channel = grpc_channel
 
     def capabilities(self):
         """Capabilities allows the client to retrieve the set of capabilities that


### PR DESCRIPTION
Adds a reference to the gRPC channel as `Client._channel` as well as modifies the `ClientBuilder.construct` method with a `return_channel` boolean argument which modifies the return behavior to return the constructed `Client` as well as the channel.

Fixes #56 