### PR TITLE
Flatten GetResponse/SubscribeResponse

### DIFF
--- a/src/cisco_gnmi/__init__.py
+++ b/src/cisco_gnmi/__init__.py
@@ -29,5 +29,6 @@ from .xr import XRClient
 from .nx import NXClient
 from .xe import XEClient
 from .builder import ClientBuilder
+from . import flatten
 
-__version__ = "1.0.10"
+__version__ = "1.0.11"

--- a/src/cisco_gnmi/cli.py
+++ b/src/cisco_gnmi/cli.py
@@ -147,9 +147,7 @@ def gnmi_subscribe():
         choices=proto.gnmi_pb2.Encoding.keys(),
     )
     parser.add_argument(
-        "-flatten",
-        help="Flatten the SubscribeResponse output.",
-        action="store_true"
+        "-flatten", help="Flatten the SubscribeResponse output.", action="store_true"
     )
     args = __common_args_handler(parser)
     # Set default XPath outside of argparse due to default being persistent in argparse.
@@ -186,7 +184,9 @@ def gnmi_subscribe():
                 synced = True
             if not synced and args.sync_start:
                 continue
-            formatted_message = __format_message(subscribe_response, args.dump_json, args.flatten)
+            formatted_message = __format_message(
+                subscribe_response, args.dump_json, args.flatten
+            )
             if args.dump_file == "stdout":
                 logging.info(formatted_message)
             else:
@@ -225,9 +225,7 @@ def gnmi_get():
         action="store_true",
     )
     parser.add_argument(
-        "-flatten",
-        help="Flatten the SubscribeResponse output.",
-        action="store_true"
+        "-flatten", help="Flatten the GetResponse output.", action="store_true"
     )
     args = __common_args_handler(parser)
     # Set default XPath outside of argparse due to default being persistent in argparse.
@@ -321,7 +319,9 @@ def __gen_client(args):
 def __format_message(message, as_json=False, as_flat=False):
     formatted_message = None
     if as_flat:
-        formatted_message = json.dumps(flatten.flatten(message), sort_keys=True, indent=4)
+        formatted_message = json.dumps(
+            flatten.flatten(message), sort_keys=True, indent=4
+        )
     elif as_json:
         formatted_message = json_format.MessageToJson(message, sort_keys=True)
     else:

--- a/src/cisco_gnmi/flatten.py
+++ b/src/cisco_gnmi/flatten.py
@@ -32,32 +32,43 @@ def _flatten_subscribe_response(subscribe_response):
     pass
 
 def _flatten_yang_json(yang_json):
+    return __flatten_yang_json_element("", yang_json)
+
+def __flatten_yang_json_element(prefix, fields, convert_strings=True):
     flattened = {}
-    for key, value in yang_json:
-        ykey = "/{}".format(key)
-        path, value = __flatten_yang_json_element(ykey, value)
-        flattened[path] = value
-    return flattened
-
-def __flatten_yang_json_element(prefix, fields):
-    flattened = []
-    for key, value in fields.items():
-        curr_path = "{}/{}".format(prefix, key)
-        keys = {}
-        values = {}
-        if isinstance(value, dict):
-            for _key, _value in value.items():
-                if isinstance(_value, str):
+    keys = {}
+    values = {}
+    to_traverse = {}
+    if isinstance(fields, list):
+        for elem in fields:
+            flattened.update(__flatten_yang_json_element(prefix, elem))
+    elif isinstance(fields, dict):
+        for key, value in fields.items():
+            if isinstance(value, str):
+                if convert_strings:
                     try:
-                        values[_key] = int(_value)
+                        values[key] = int(value)
                     except ValueError:
-                        keys[_key] = _value
-                elif isinstance(_value, int):
-                    values[_key] = _value
-            
-
-
-            return __flatten_yang_json_element(curr_path, value)
-        if isinstance(value, list):
-            keys, fields = __flatten_yang_json_element(curr_path, value)
+                        try:
+                            values[key] = float(value)
+                        except ValueError:
+                            keys[key] = value
+                else:
+                    keys[key] = value
+            elif isinstance(value, (int, float)):
+                values[key] = value
+            elif isinstance(value, (dict, list)):
+                to_traverse[key] = value
+            else:
+                raise Exception("Unhandled element type!")
+        key_string = ""
+        for key, value in keys.items():
+            key_string += "[{key}={value}]".format(key=key, value=value)
+        for key, value in to_traverse.items():
+            keyed_elem = "{prefix}{keys}/{elem}".format(prefix=prefix, elem=key, keys=key_string)
+            flattened.update(__flatten_yang_json_element(keyed_elem, value, convert_strings))
+        for key, value in values.items():
+            keyed_elem = "{prefix}{keys}/{elem}".format(prefix=prefix, elem=key, keys=key_string)
+            flattened[keyed_elem] = value
+    return flattened
         

--- a/src/cisco_gnmi/flatten.py
+++ b/src/cisco_gnmi/flatten.py
@@ -1,3 +1,4 @@
+import json
 from . import proto
 
 def parse_path_to_xpath(path):
@@ -10,40 +11,53 @@ def parse_path_to_xpath(path):
     return origin, xpath
 
 def flatten(message):
-    op_map = {
-        proto.gnmi_pb2.GetResponse: _flatten_get_response,
-        proto.gnmi_pb2.SubscribeResponse: _flatten_subscribe_response
+    flatten_method_map = {
+        proto.gnmi_pb2.GetResponse: _flatten_get_response
     }
     identified = False
-    for message_class, op in op_map.items():
+    flattened_message = None
+    for message_class, flatten_method in flatten_method_map.items():
         if isinstance(message, message_class):
             identified = True
-            op(message)
+            flattened_message = flatten_method(message)
     if not identified:
         raise Exception("Flatten not yet supported for message class!")
+    return flattened_message
 
 def _flatten_get_response(get_response):
     flattened_response = {}
     for notification in get_response.notification:
-        _, xpath = parse_path_to_xpath(notification.path)
-        value = 
+        _, xpath_prefix = parse_path_to_xpath(notification.prefix)
+        for update in notification.update:
+            _, xpath_update = parse_path_to_xpath(update.path)
+            xpath = ""
+            if xpath_prefix and xpath_update:
+                xpath = "{}/{}".format(xpath_prefix, xpath_update)
+            elif xpath_prefix:
+                xpath = xpath_prefix
+            elif xpath_update:
+                xpath = xpath_update
+            update_name = update.WhichOneOf("value")
+            update_value = getattr(update, update_name)
+            if update_name in {"json_val", "json_ietf_val"}:
+                raw_json = getattr(update, update_name)
+                serialized_json = json.load(raw_json)
+                sub_flattened_response = flatten_yang_json(xpath, serialized_json)
+                flattened_response.update(sub_flattened_response)
+            else:
+                flattened_response[xpath] = update_value
+    return flattened_response
 
-def _flatten_subscribe_response(subscribe_response):
-    pass
-
-def _flatten_yang_json(yang_json):
-    return __flatten_yang_json_element("", yang_json)
-
-def __flatten_yang_json_element(prefix, fields, convert_strings=True):
+def flatten_yang_json(prefix, yang_json, convert_strings=True):
     flattened = {}
     keys = {}
     values = {}
     to_traverse = {}
-    if isinstance(fields, list):
-        for elem in fields:
-            flattened.update(__flatten_yang_json_element(prefix, elem))
-    elif isinstance(fields, dict):
-        for key, value in fields.items():
+    if isinstance(yang_json, list):
+        for elem in yang_json:
+            flattened.update(flatten_yang_json(prefix, elem))
+    elif isinstance(yang_json, dict):
+        for key, value in yang_json.items():
             if isinstance(value, str):
                 if convert_strings:
                     try:
@@ -66,7 +80,7 @@ def __flatten_yang_json_element(prefix, fields, convert_strings=True):
             key_string += "[{key}={value}]".format(key=key, value=value)
         for key, value in to_traverse.items():
             keyed_elem = "{prefix}{keys}/{elem}".format(prefix=prefix, elem=key, keys=key_string)
-            flattened.update(__flatten_yang_json_element(keyed_elem, value, convert_strings))
+            flattened.update(flatten_yang_json(keyed_elem, value, convert_strings))
         for key, value in values.items():
             keyed_elem = "{prefix}{keys}/{elem}".format(prefix=prefix, elem=key, keys=key_string)
             flattened[keyed_elem] = value

--- a/src/cisco_gnmi/flatten.py
+++ b/src/cisco_gnmi/flatten.py
@@ -1,20 +1,43 @@
+"""Copyright 2020 Cisco Systems
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+
+The contents of this file are licensed under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+"""
+
+"""Helper functions to flatten nested gNMI message data.
+e.g. "/interfaces/interface[name=HundredGigE0/0/0/12]/state/counters/in-broadcast-pkts": 0
+"""
 import json
 import logging
 from . import proto
 
-def parse_path_to_xpath(path):
-    origin = path.origin
-    xpath = ""
-    for elem in path.elem:
-        xpath += "/{}".format(elem.name)
-        for key in elem.key:
-            xpath += "[{}={}]".format(key, elem.key[key])
-    return origin, xpath
 
 def flatten(message, convert_strings=True, ignore_delete=True):
+    """Top level convenience function which accepts a protobuf
+    message and indirects to the appropriate handler function to
+    flatten the data to a simple, flat xpath:value dict representation.
+    Currently only handles GetResponse and SubscribeResponse.
+    """
     flatten_method_map = {
         proto.gnmi_pb2.GetResponse: _flatten_get_response,
-        proto.gnmi_pb2.SubscribeResponse: _flatten_subscribe_response
+        proto.gnmi_pb2.SubscribeResponse: _flatten_subscribe_response,
     }
     identified = False
     flattened_message = None
@@ -26,54 +49,13 @@ def flatten(message, convert_strings=True, ignore_delete=True):
         raise Exception("Flatten not yet supported for message class!")
     return flattened_message
 
-def _flatten_get_response(get_response, convert_strings=True, ignore_delete=True):
-    flattened_response = {}
-    for notification in get_response.notification:
-        flattened_response.update(__flatten_notification(notification))
-    return flattened_response
-
-def _flatten_subscribe_response(subscribe_response, convert_strings=True, ignore_delete=True):
-    return __flatten_notification(subscribe_response.update)
-
-def __flatten_notification(notification_message, convert_strings=True, ignore_delete=True):
-    flattened_response = {}
-    _, xpath_prefix = parse_path_to_xpath(notification_message.prefix)
-    def __realize_xpath(_prefix, _suffix):
-        _xpath = ""
-        if _prefix and _suffix:
-            _xpath = "{}/{}".format(_prefix, _suffix)
-        elif _prefix:
-            _xpath = _prefix
-        elif _suffix:
-            _xpath = _suffix
-        return _xpath
-    for update in notification_message.update:
-        _, xpath_update = parse_path_to_xpath(update.path)
-        xpath = __realize_xpath(xpath_prefix, xpath_update)
-        value_name = update.val.WhichOneof("value")
-        update_value = getattr(update.val, value_name)
-        if value_name in {"json_val", "json_ietf_val"}:
-            serialized_json = None
-            try:
-                json_content = update_value.decode("utf-8")
-                serialized_json = json.loads(json_content)
-            except json.decoder.JSONDecodeError as e:
-                logging.error(json_content)
-                raise e
-            sub_flattened_response = flatten_yang_json(xpath, serialized_json, convert_strings)
-            flattened_response.update(sub_flattened_response)
-        else:
-            flattened_response[xpath] = update_value
-    if not ignore_delete:
-        for path in notification_message.delete:
-            _, xpath_delete = parse_path_to_xpath(path)
-            xpath = __realize_xpath(xpath_prefix, xpath_delete)
-            if xpath in flattened_response.keys():
-                raise Exception("Deleted element in update messages!")
-            flattened_response[xpath] = None
-    return flattened_response
 
 def flatten_yang_json(prefix, yang_json, convert_strings=True):
+    """Flattens a JSON structure with special consideration
+    around strings - inlining like keys and attempting integer
+    conversion given the uint64-as-string JSON encoding rules.
+    Recursive implementation, many dict updates, not intensely validated.
+    """
     flattened = {}
     keys = {}
     values = {}
@@ -104,10 +86,82 @@ def flatten_yang_json(prefix, yang_json, convert_strings=True):
         for key, value in keys.items():
             key_string += "[{key}={value}]".format(key=key, value=value)
         for key, value in to_traverse.items():
-            keyed_elem = "{prefix}{keys}/{elem}".format(prefix=prefix, elem=key, keys=key_string)
+            keyed_elem = "{prefix}{keys}/{elem}".format(
+                prefix=prefix, elem=key, keys=key_string
+            )
             flattened.update(flatten_yang_json(keyed_elem, value, convert_strings))
         for key, value in values.items():
-            keyed_elem = "{prefix}{keys}/{elem}".format(prefix=prefix, elem=key, keys=key_string)
+            keyed_elem = "{prefix}{keys}/{elem}".format(
+                prefix=prefix, elem=key, keys=key_string
+            )
             flattened[keyed_elem] = value
     return flattened
-        
+
+
+def parse_path_to_xpath(path):
+    """Parses a gNMI Path to XPath equivalent."""
+    origin = path.origin
+    xpath = ""
+    for elem in path.elem:
+        xpath += "/{}".format(elem.name)
+        for key in elem.key:
+            xpath += "[{}={}]".format(key, elem.key[key])
+    return origin, xpath
+
+
+def _flatten_get_response(get_response, convert_strings=True, ignore_delete=True):
+    flattened_response = {}
+    for notification in get_response.notification:
+        flattened_response.update(__flatten_notification(notification))
+    return flattened_response
+
+
+def _flatten_subscribe_response(
+    subscribe_response, convert_strings=True, ignore_delete=True
+):
+    return __flatten_notification(subscribe_response.update)
+
+
+def __flatten_notification(
+    notification_message, convert_strings=True, ignore_delete=True
+):
+    flattened_response = {}
+    _, xpath_prefix = parse_path_to_xpath(notification_message.prefix)
+
+    def __realize_xpath(_prefix, _suffix):
+        _xpath = ""
+        if _prefix and _suffix:
+            _xpath = "{}/{}".format(_prefix, _suffix)
+        elif _prefix:
+            _xpath = _prefix
+        elif _suffix:
+            _xpath = _suffix
+        return _xpath
+
+    for update in notification_message.update:
+        _, xpath_update = parse_path_to_xpath(update.path)
+        xpath = __realize_xpath(xpath_prefix, xpath_update)
+        value_name = update.val.WhichOneof("value")
+        update_value = getattr(update.val, value_name)
+        if value_name in {"json_val", "json_ietf_val"}:
+            serialized_json = None
+            try:
+                json_content = update_value.decode("utf-8")
+                serialized_json = json.loads(json_content)
+            except json.decoder.JSONDecodeError as e:
+                logging.error(json_content)
+                raise e
+            sub_flattened_response = flatten_yang_json(
+                xpath, serialized_json, convert_strings
+            )
+            flattened_response.update(sub_flattened_response)
+        else:
+            flattened_response[xpath] = update_value
+    if not ignore_delete:
+        for path in notification_message.delete:
+            _, xpath_delete = parse_path_to_xpath(path)
+            xpath = __realize_xpath(xpath_prefix, xpath_delete)
+            if xpath in flattened_response.keys():
+                raise Exception("Deleted element in update messages!")
+            flattened_response[xpath] = None
+    return flattened_response

--- a/src/cisco_gnmi/flatten.py
+++ b/src/cisco_gnmi/flatten.py
@@ -1,0 +1,63 @@
+from . import proto
+
+def parse_path_to_xpath(path):
+    origin = path.origin
+    xpath = ""
+    for elem in path.elem:
+        xpath += "/{}".format(elem.name)
+        for key in elem.key:
+            xpath += "[{}={}]".format(key, elem.key[key])
+    return origin, xpath
+
+def flatten(message):
+    op_map = {
+        proto.gnmi_pb2.GetResponse: _flatten_get_response,
+        proto.gnmi_pb2.SubscribeResponse: _flatten_subscribe_response
+    }
+    identified = False
+    for message_class, op in op_map.items():
+        if isinstance(message, message_class):
+            identified = True
+            op(message)
+    if not identified:
+        raise Exception("Flatten not yet supported for message class!")
+
+def _flatten_get_response(get_response):
+    flattened_response = {}
+    for notification in get_response.notification:
+        _, xpath = parse_path_to_xpath(notification.path)
+        value = 
+
+def _flatten_subscribe_response(subscribe_response):
+    pass
+
+def _flatten_yang_json(yang_json):
+    flattened = {}
+    for key, value in yang_json:
+        ykey = "/{}".format(key)
+        path, value = __flatten_yang_json_element(ykey, value)
+        flattened[path] = value
+    return flattened
+
+def __flatten_yang_json_element(prefix, fields):
+    flattened = []
+    for key, value in fields.items():
+        curr_path = "{}/{}".format(prefix, key)
+        keys = {}
+        values = {}
+        if isinstance(value, dict):
+            for _key, _value in value.items():
+                if isinstance(_value, str):
+                    try:
+                        values[_key] = int(_value)
+                    except ValueError:
+                        keys[_key] = _value
+                elif isinstance(_value, int):
+                    values[_key] = _value
+            
+
+
+            return __flatten_yang_json_element(curr_path, value)
+        if isinstance(value, list):
+            keys, fields = __flatten_yang_json_element(curr_path, value)
+        

--- a/src/cisco_gnmi/flatten.py
+++ b/src/cisco_gnmi/flatten.py
@@ -78,6 +78,9 @@ def flatten_yang_json(prefix, yang_json, convert_strings=True):
                             keys[key] = value
                 else:
                     keys[key] = value
+            # Fun fact, boolean is a sub of int in Python
+            elif isinstance(value, bool):
+                keys[key] = json.dumps(value)
             elif isinstance(value, (int, float)):
                 values[key] = value
             elif isinstance(value, (dict, list)):


### PR DESCRIPTION
Responses to Get and Subscribe can be deeply nested, this will provide a flattened view.

e.g.
```
DEBUG:root:SubscribeResponse received.
INFO:root:{
    "/Cisco-IOS-XR-ethernet-lldp-oper:lldp/nodes/node[node-name=0/RP0/CPU0]/statistics/aged-out-entries": 0,
    "/Cisco-IOS-XR-ethernet-lldp-oper:lldp/nodes/node[node-name=0/RP0/CPU0]/statistics/bad-packets": 0,
    "/Cisco-IOS-XR-ethernet-lldp-oper:lldp/nodes/node[node-name=0/RP0/CPU0]/statistics/discarded-packets": 0,
    "/Cisco-IOS-XR-ethernet-lldp-oper:lldp/nodes/node[node-name=0/RP0/CPU0]/statistics/discarded-tl-vs": 0,
    "/Cisco-IOS-XR-ethernet-lldp-oper:lldp/nodes/node[node-name=0/RP0/CPU0]/statistics/encapsulation-errors": 0,
    "/Cisco-IOS-XR-ethernet-lldp-oper:lldp/nodes/node[node-name=0/RP0/CPU0]/statistics/out-of-memory-errors": 0,
    "/Cisco-IOS-XR-ethernet-lldp-oper:lldp/nodes/node[node-name=0/RP0/CPU0]/statistics/queue-overflow-errors": 0,
    "/Cisco-IOS-XR-ethernet-lldp-oper:lldp/nodes/node[node-name=0/RP0/CPU0]/statistics/received-packets": 0,
    "/Cisco-IOS-XR-ethernet-lldp-oper:lldp/nodes/node[node-name=0/RP0/CPU0]/statistics/table-overflow-errors": 0,
    "/Cisco-IOS-XR-ethernet-lldp-oper:lldp/nodes/node[node-name=0/RP0/CPU0]/statistics/transmitted-packets": 0,
    "/Cisco-IOS-XR-ethernet-lldp-oper:lldp/nodes/node[node-name=0/RP0/CPU0]/statistics/unrecognized-tl-vs": 0
}
```

Fixes #60 