### PR TITLE
parse_xpath_to_gnmi_path as classmethod

### DIFF
--- a/src/cisco_gnmi/__init__.py
+++ b/src/cisco_gnmi/__init__.py
@@ -30,4 +30,4 @@ from .nx import NXClient
 from .xe import XEClient
 from .builder import ClientBuilder
 
-__version__ = "1.0.10"
+__version__ = "1.0.11"

--- a/src/cisco_gnmi/client.py
+++ b/src/cisco_gnmi/client.py
@@ -402,7 +402,8 @@ class Client(object):
         subscription_list.subscription.extend(subscriptions)
         return self.subscribe([subscription_list])
 
-    def parse_xpath_to_gnmi_path(self, xpath, origin=None):
+    @classmethod
+    def parse_xpath_to_gnmi_path(cls, xpath, origin=None):
         """Parses an XPath to proto.gnmi_pb2.Path.
         This function should be overridden by any child classes for origin logic.
 

--- a/src/cisco_gnmi/nx.py
+++ b/src/cisco_gnmi/nx.py
@@ -152,7 +152,8 @@ class NXClient(Client):
             heartbeat_interval,
         )
 
-    def parse_xpath_to_gnmi_path(self, xpath, origin=None):
+    @classmethod
+    def parse_xpath_to_gnmi_path(cls, xpath, origin=None):
         """Attempts to determine whether origin should be YANG (device) or DME.
         Errors on OpenConfig until support is present.
         """
@@ -169,4 +170,4 @@ class NXClient(Client):
                 xpath = xpath.split(":", 1)[1]
             else:
                 origin = "DME"
-        return super(NXClient, self).parse_xpath_to_gnmi_path(xpath, origin)
+        return super(NXClient, cls).parse_xpath_to_gnmi_path(xpath, origin)

--- a/src/cisco_gnmi/xe.py
+++ b/src/cisco_gnmi/xe.py
@@ -307,7 +307,8 @@ class XEClient(Client):
             heartbeat_interval,
         )
 
-    def parse_xpath_to_gnmi_path(self, xpath, origin=None):
+    @classmethod
+    def parse_xpath_to_gnmi_path(cls, xpath, origin=None):
         """Naively tries to intelligently (non-sequitur!) origin
         Otherwise assume rfc7951
         legacy is not considered
@@ -318,4 +319,4 @@ class XEClient(Client):
                 origin = "openconfig"
             else:
                 origin = "rfc7951"
-        return super(XEClient, self).parse_xpath_to_gnmi_path(xpath, origin)
+        return super(XEClient, cls).parse_xpath_to_gnmi_path(xpath, origin)

--- a/src/cisco_gnmi/xr.py
+++ b/src/cisco_gnmi/xr.py
@@ -338,7 +338,8 @@ class XRClient(Client):
             heartbeat_interval,
         )
 
-    def parse_xpath_to_gnmi_path(self, xpath, origin=None):
+    @classmethod
+    def parse_xpath_to_gnmi_path(cls, xpath, origin=None):
         """No origin specified implies openconfig
         Otherwise origin is expected to be the module name
         """
@@ -351,9 +352,10 @@ class XRClient(Client):
                 # module name
                 origin, xpath = xpath.split(":", 1)
                 origin = origin.strip("/")
-        return super(XRClient, self).parse_xpath_to_gnmi_path(xpath, origin)
+        return super(XRClient, cls).parse_xpath_to_gnmi_path(xpath, origin)
 
-    def parse_cli_to_gnmi_path(self, command):
+    @classmethod
+    def parse_cli_to_gnmi_path(cls, command):
         """Parses a CLI command to proto.gnmi_pb2.Path.
         IOS XR appears to be the only OS with this functionality.
 


### PR DESCRIPTION
Makes it simpler to derive XPaths for OSes without having a built `Client`.

e.g.
```
(cisco-gnmi-python) [cisco-gnmi-python] python3
Type "help", "copyright", "credits" or "license" for more information.
>>> from cisco_gnmi import XRClient
>>> XRClient.parse_xpath_to_gnmi_path("/openconfig-interfaces:interfaces/interface/state/openconfig-vlan:tpid")
origin: "openconfig-interfaces"
elem {
  name: "interfaces"
}
elem {
  name: "interface"
}
elem {
  name: "state"
}
elem {
  name: "openconfig-vlan:tpid"
}
```

Fixes #61 