### PR TITLE
CLI Subscribe request Mode

### DIFF
--- a/src/cisco_gnmi/__init__.py
+++ b/src/cisco_gnmi/__init__.py
@@ -30,4 +30,4 @@ from .nx import NXClient
 from .xe import XEClient
 from .builder import ClientBuilder
 
-__version__ = "1.0.10"
+__version__ = "1.0.11"

--- a/src/cisco_gnmi/cli.py
+++ b/src/cisco_gnmi/cli.py
@@ -114,6 +114,12 @@ def gnmi_subscribe():
         choices=proto.gnmi_pb2.SubscriptionMode.keys(),
     )
     parser.add_argument(
+        "-req_mode",
+        help="SubscriptionList.Mode mode for Subscriptions. Defaults to STREAM.",
+        default="STREAM",
+        choices=proto.gnmi_pb2.SubscriptionList.Mode.keys(),
+    )
+    parser.add_argument(
         "-suppress_redundant",
         help="Suppress redundant information in Subscription.",
         action="store_true",
@@ -159,6 +165,8 @@ def gnmi_subscribe():
         kwargs["sample_interval"] = args.interval * int(1e9)
     if args.mode:
         kwargs["sub_mode"] = args.mode
+    if args.req_mode:
+        kwargs["request_mode"] = args.req_mode
     if args.suppress_redundant:
         kwargs["suppress_redundant"] = args.suppress_redundant
     if args.heartbeat_interval:


### PR DESCRIPTION
Specify `SubscribeRequest.SubscriptionList.Mode` from CLI. Previously only did default, usually `STREAM`. Required for `ONCE`, etc.

Fixes #64 