### PR TITLE
Revert "Release v1.0.12"

### DIFF
--- a/src/cisco_gnmi/__init__.py
+++ b/src/cisco_gnmi/__init__.py
@@ -30,4 +30,4 @@ from .nx import NXClient
 from .xe import XEClient
 from .builder import ClientBuilder
 
-__version__ = "1.0.12"
+__version__ = "1.0.11"

--- a/src/cisco_gnmi/cli.py
+++ b/src/cisco_gnmi/cli.py
@@ -114,12 +114,6 @@ def gnmi_subscribe():
         choices=proto.gnmi_pb2.SubscriptionMode.keys(),
     )
     parser.add_argument(
-        "-req_mode",
-        help="SubscriptionList.Mode mode for Subscriptions. Defaults to STREAM.",
-        default="STREAM",
-        choices=proto.gnmi_pb2.SubscriptionList.Mode.keys(),
-    )
-    parser.add_argument(
         "-suppress_redundant",
         help="Suppress redundant information in Subscription.",
         action="store_true",
@@ -165,8 +159,6 @@ def gnmi_subscribe():
         kwargs["sample_interval"] = args.interval * int(1e9)
     if args.mode:
         kwargs["sub_mode"] = args.mode
-    if args.req_mode:
-        kwargs["request_mode"] = args.req_mode
     if args.suppress_redundant:
         kwargs["suppress_redundant"] = args.suppress_redundant
     if args.heartbeat_interval:

--- a/src/cisco_gnmi/client.py
+++ b/src/cisco_gnmi/client.py
@@ -408,8 +408,7 @@ class Client(object):
         subscription_list.subscription.extend(subscriptions)
         return self.subscribe([subscription_list])
 
-    @classmethod
-    def parse_xpath_to_gnmi_path(cls, xpath, origin=None):
+    def parse_xpath_to_gnmi_path(self, xpath, origin=None):
         """Parses an XPath to proto.gnmi_pb2.Path.
         This function should be overridden by any child classes for origin logic.
 

--- a/src/cisco_gnmi/nx.py
+++ b/src/cisco_gnmi/nx.py
@@ -289,8 +289,7 @@ class NXClient(Client):
             heartbeat_interval,
         )
 
-    @classmethod
-    def parse_xpath_to_gnmi_path(cls, xpath, origin=None):
+    def parse_xpath_to_gnmi_path(self, xpath, origin=None):
         """Attempts to determine whether origin should be YANG (device) or DME.
         """
         if origin is None:

--- a/src/cisco_gnmi/xe.py
+++ b/src/cisco_gnmi/xe.py
@@ -312,8 +312,7 @@ class XEClient(Client):
             prefix
         )
 
-    @classmethod
-    def parse_xpath_to_gnmi_path(cls, xpath, origin=None):
+    def parse_xpath_to_gnmi_path(self, xpath, origin=None):
         """Naively tries to intelligently (non-sequitur!) origin
         Otherwise assume rfc7951
         legacy is not considered
@@ -324,4 +323,4 @@ class XEClient(Client):
                 origin = "openconfig"
             else:
                 origin = "rfc7951"
-        return super(XEClient, cls).parse_xpath_to_gnmi_path(xpath, origin)
+        return super(XEClient, self).parse_xpath_to_gnmi_path(xpath, origin)

--- a/src/cisco_gnmi/xr.py
+++ b/src/cisco_gnmi/xr.py
@@ -338,8 +338,7 @@ class XRClient(Client):
             heartbeat_interval,
         )
 
-    @classmethod
-    def parse_xpath_to_gnmi_path(cls, xpath, origin=None):
+    def parse_xpath_to_gnmi_path(self, xpath, origin=None):
         """No origin specified implies openconfig
         Otherwise origin is expected to be the module name
         """
@@ -352,10 +351,9 @@ class XRClient(Client):
                 # module name
                 origin, xpath = xpath.split(":", 1)
                 origin = origin.strip("/")
-        return super(XRClient, cls).parse_xpath_to_gnmi_path(xpath, origin)
+        return super(XRClient, self).parse_xpath_to_gnmi_path(xpath, origin)
 
-    @classmethod
-    def parse_cli_to_gnmi_path(cls, command):
+    def parse_cli_to_gnmi_path(self, command):
         """Parses a CLI command to proto.gnmi_pb2.Path.
         IOS XR appears to be the only OS with this functionality.
 


### PR DESCRIPTION
Reverts cisco-ie/cisco-gnmi-python#75

```
hi
thanks
performed an upgrade
now the original client request is failing

log?

cisco-gnmi get -encoding JSON -data_type STATE -os NX-OS -root_certificates gnmi.pem -ssl_target_override ems.cisco.com -xpath "/interfaces/interface[name='eth1/1']" x:x
Username: admin
Password:
ERROR:root:Error during usage!
Traceback (most recent call last):
File "/lib/python3.6/site-packages/cisco_gnmi/cli.py", line 79, in main
rpc_map[args.rpc]()
File "/lib/python3.6/site-packages/cisco_gnmi/cli.py", line 240, in gnmi_get
get_response = client.get_xpaths(args.xpath, **kwargs)
File "/lib/python3.6/site-packages/cisco_gnmi/nx.py", line 201, in get_xpaths
return self.get(gnmi_path, data_type=data_type, encoding=encoding)
File "/lib/python3.6/site-packages/cisco_gnmi/client.py", line 164, in get
request.path.extend(paths)
File "/lib/python3.6/site-packages/cisco_gnmi/nx.py", line 309, in parse_xpath_to_gnmi_path
return super(NXClient, self).parse_xpath_to_gnmi_path(xpath, origin)
NameError: name 'self' is not defined
```