### PR TITLE
added prefix for xr

### DIFF
--- a/src/cisco_gnmi/xr.py
+++ b/src/cisco_gnmi/xr.py
@@ -253,6 +253,7 @@ class XRClient(Client):
         sample_interval=Client._NS_IN_S * 10,
         suppress_redundant=False,
         heartbeat_interval=None,
+        prefix=None,
     ):
         """A convenience wrapper of subscribe() which aids in building of SubscriptionRequest
         with request as subscribe SubscriptionList. This method accepts an iterable of simply xpath strings,
@@ -296,6 +297,8 @@ class XRClient(Client):
             Specifies the maximum allowable silent period in nanoseconds when
             suppress_redundant is in use. The target should send a value at least once
             in the period specified.
+        prefix: proto.Path, optional
+            Prefix path that can be used as a general path to prepend to all Path elements. (might not be supported on XR)
 
         Returns
         -------
@@ -336,6 +339,7 @@ class XRClient(Client):
             sample_interval,
             suppress_redundant,
             heartbeat_interval,
+            prefix,
         )
 
     @classmethod


### PR DESCRIPTION
erroring out when I try to use XRClient as same as XE/NX for gNMI subcribe from pyATS yang.connector.
```
File /nobackup/tahigash/pyats_dev_2207/pypi/yang/connector/src/yang/connector/gnmi.py:720, in Gnmi.subscribe(self, cmd)
    718 format = cmd['format']
    719 subscribe_xpaths = msg['get']
--> 720 subscribe_response = self.gnmi.subscribe_xpaths(
    721     subscribe_xpaths,
    722     format.get('request_mode', 'STREAM'),
    723     format.get('sub_mode', 'SAMPLE'),
    724     format.get('encoding', 'JSON_IETF'),
    725     self.gnmi._NS_IN_S * format.get('sample_interval', 10),
    726     prefix=prefix
    727 )
    728 if format.get('request_mode', 'STREAM') == 'ONCE':
    729     # Do fixup in response
    730     response_verify = cmd.get('verifier')

TypeError: subscribe_xpaths() got an unexpected keyword argument 'prefix'
```

I believe `subscribe_xpaths()` is supposed to have same arguments across OSes. but `iosxr` was missing `prefix`. so added.

